### PR TITLE
Windows >= 10.0.10586, greater ANSI support

### DIFF
--- a/System/Console/ANSI.hs
+++ b/System/Console/ANSI.hs
@@ -1,4 +1,7 @@
--- | Provides ANSI terminal support for Windows and ANSI terminal software running on a Unix-like operating system.
+-- | Provides ANSI terminal support for ANSI terminal software running on a
+-- Unix-like operating system or on a Windows operating system (where supported)
+-- or on other Windows operating systems where the terminal in use is not
+-- ANSI-enabled.
 --
 -- The ANSI escape codes are described at <http://en.wikipedia.org/wiki/ANSI_escape_code> and provide a rich range of
 -- functionality for terminal control, which includes:
@@ -22,10 +25,15 @@
 --    to the supplied handle.  Commands issued like this should also work as you expect on both Windows and Unix.
 --
 --  * Strawberry: has a @String@ type and just consists of an escape code which can be added to any other bit of text
---    before being output.  This version of the API is often convenient to use, but due to fundamental limitations in
---    Windows ANSI terminal support will only work on Unix.  On Windows these codes will always be the empty string,
---    so it is possible to use them portably for e.g. coloring console output on the understanding that you will only
---    see colors if you are running on a Unix-like operating system.
+--    before being output. This version of the API is often convenient to use,
+--    but will not work on Windows operating systems where the terminal in use
+--    is not ANSI-enabled (such as those before Windows 10 Threshold 2). On
+--    versions of Windows where the terminal in use is not ANSI-enabled, these
+--    codes will always be the empty string, so it is possible to use them
+--    portably for e.g. coloring console output on the understanding that you
+--    will only see colors if you are running on an operating system that is
+--    Unix-like or is a version of Windows where the terminal in use is ANSI-
+--    enabled.
 --
 -- Example:
 --

--- a/System/Console/ANSI/Example.hs
+++ b/System/Console/ANSI/Example.hs
@@ -24,8 +24,14 @@ examples = [ cursorMovementExample
 main :: IO ()
 main = mapM_ (\example -> resetScreen >> example) examples
 
+-- Annex D to Standard ECMA-48 (5th Ed, 1991) identifies that the representation
+-- of an erased state is implementation-dependent. There may or may not be a
+-- distinction between a character position in the erased state and one imaging
+-- SPACE. Consequently, to reset the screen, the default graphic rendition must
+-- be selected (setSGR [Reset]) before all character positions are put into the
+-- erased state (clearScreen).
 resetScreen :: IO ()
-resetScreen = clearScreen >> setSGR [Reset] >> setCursorPosition 0 0
+resetScreen = setSGR [Reset] >> clearScreen >> setCursorPosition 0 0
 
 pause :: IO ()
 pause = do

--- a/System/Console/ANSI/Windows.hs
+++ b/System/Console/ANSI/Windows.hs
@@ -4,4 +4,165 @@ module System.Console.ANSI.Windows (
     ) where
 
 import System.Console.ANSI.Types
-import System.Console.ANSI.Windows.Emulator
+import qualified System.Console.ANSI.Unix as U
+import System.Console.ANSI.Windows.Detect (isANSIEnabled)
+import qualified System.Console.ANSI.Windows.Emulator as E
+import System.IO (Handle, hIsTerminalDevice, stdout)
+
+#include "Common-Include.hs"
+
+-- * Cursor movement by character
+hCursorUp = if isANSIEnabled then U.hCursorUp else E.hCursorUp
+
+hCursorDown = if isANSIEnabled then U.hCursorDown else E.hCursorDown
+
+hCursorForward = if isANSIEnabled then U.hCursorForward else E.hCursorForward
+
+hCursorBackward = if isANSIEnabled then U.hCursorBackward else E.hCursorBackward
+
+cursorUpCode :: Int -> String
+cursorUpCode = if isANSIEnabled then U.cursorUpCode else E.cursorUpCode
+
+cursorDownCode :: Int -> String
+cursorDownCode = if isANSIEnabled then U.cursorDownCode else E.cursorDownCode
+
+cursorForwardCode :: Int -> String
+cursorForwardCode = if isANSIEnabled
+                    then U.cursorForwardCode
+                    else E.cursorForwardCode
+
+cursorBackwardCode :: Int -> String
+cursorBackwardCode = if isANSIEnabled
+                     then U.cursorBackwardCode
+                     else E.cursorBackwardCode
+
+-- * Cursor movement by line
+hCursorUpLine = if isANSIEnabled then U.hCursorUpLine else E.hCursorUpLine
+
+hCursorDownLine = if isANSIEnabled then U.hCursorDownLine else E.hCursorDownLine
+
+cursorUpLineCode :: Int -> String
+cursorUpLineCode = if isANSIEnabled
+                   then U.cursorUpLineCode
+                   else E.cursorUpLineCode
+
+cursorDownLineCode :: Int -> String
+cursorDownLineCode = if isANSIEnabled
+                     then U.cursorDownLineCode
+                     else E.cursorDownLineCode
+
+-- * Directly changing cursor position
+hSetCursorColumn = if isANSIEnabled
+                   then U.hSetCursorColumn
+                   else E.hSetCursorColumn
+
+setCursorColumnCode :: Int -> String
+setCursorColumnCode = if isANSIEnabled
+                      then U.setCursorColumnCode
+                      else E.setCursorColumnCode
+
+hSetCursorPosition = if isANSIEnabled 
+                     then U.hSetCursorPosition
+                     else E.hSetCursorPosition
+
+setCursorPositionCode :: Int -> Int -> String
+setCursorPositionCode = if isANSIEnabled
+                        then U.setCursorPositionCode
+                        else E.setCursorPositionCode
+
+-- * Clearing parts of the screen
+hClearFromCursorToScreenEnd = if isANSIEnabled
+                              then U.hClearFromCursorToScreenEnd
+                              else E.hClearFromCursorToScreenEnd
+
+hClearFromCursorToScreenBeginning = if isANSIEnabled
+                                    then U.hClearFromCursorToScreenBeginning
+                                    else E.hClearFromCursorToScreenBeginning
+
+hClearScreen = if isANSIEnabled then U.hClearScreen else E.hClearScreen
+
+clearFromCursorToScreenEndCode :: String
+clearFromCursorToScreenEndCode = if isANSIEnabled
+                                 then U.clearFromCursorToScreenEndCode
+                                 else E.clearFromCursorToScreenEndCode
+
+clearFromCursorToScreenBeginningCode :: String
+clearFromCursorToScreenBeginningCode =
+    if isANSIEnabled
+    then U.clearFromCursorToScreenBeginningCode
+    else E.clearFromCursorToScreenBeginningCode
+
+clearScreenCode :: String
+clearScreenCode = if isANSIEnabled then U.clearScreenCode else E.clearScreenCode
+
+hClearFromCursorToLineEnd = if isANSIEnabled
+                            then U.hClearFromCursorToLineEnd 
+                            else E.hClearFromCursorToLineEnd
+
+hClearFromCursorToLineBeginning = if isANSIEnabled 
+                                  then U.hClearFromCursorToLineBeginning
+                                  else E.hClearFromCursorToLineBeginning
+
+hClearLine = if isANSIEnabled then U.hClearLine else E.hClearLine
+
+clearFromCursorToLineEndCode :: String
+clearFromCursorToLineEndCode = if isANSIEnabled
+                               then U.clearFromCursorToLineEndCode
+                               else E.clearFromCursorToLineEndCode
+
+clearFromCursorToLineBeginningCode :: String
+clearFromCursorToLineBeginningCode = if isANSIEnabled
+                                     then U.clearFromCursorToLineBeginningCode
+                                     else E.clearFromCursorToLineBeginningCode
+
+clearLineCode :: String
+clearLineCode = if isANSIEnabled then U.clearLineCode else E.clearLineCode
+
+-- * Scrolling the screen
+hScrollPageUp = if isANSIEnabled then U.hScrollPageUp else E.hScrollPageUp
+hScrollPageDown = if isANSIEnabled then U.hScrollPageDown else E.hScrollPageDown
+
+scrollPageUpCode :: Int -> String
+scrollPageUpCode = if isANSIEnabled
+                   then U.scrollPageUpCode
+                   else E.scrollPageUpCode
+
+scrollPageDownCode :: Int -> String
+scrollPageDownCode = if isANSIEnabled
+                     then U.scrollPageDownCode
+                     else E.scrollPageDownCode
+
+-- * Select Graphic Rendition mode: colors and other whizzy stuff
+--
+-- The following SGR codes are NOT implemented by Windows 10 Threshold 2:
+-- 2   SetConsoleIntensity FaintIntensity
+-- 3   SetItalicized True
+-- 5   SetBlinkSpeed SlowBlink
+-- 6   SetBlinkSpeed RapidBlink
+-- 8   SetVisible False
+-- 21  SetUnderlining DoubleUnderline
+-- 23  SetItalicized False
+-- 25  SetBlinkSpeed NoBlink
+-- 28  SetVisible True
+
+hSetSGR = if isANSIEnabled then U.hSetSGR else E.hSetSGR
+
+setSGRCode :: [SGR] -> String
+setSGRCode = if isANSIEnabled then U.setSGRCode else E.setSGRCode
+
+-- * Cursor visibilty changes
+hHideCursor = if isANSIEnabled then U.hHideCursor else E.hHideCursor
+
+hShowCursor = if isANSIEnabled then U.hShowCursor else E.hShowCursor
+
+hideCursorCode :: String
+hideCursorCode = if isANSIEnabled then U.hideCursorCode else E.hideCursorCode
+
+showCursorCode :: String
+showCursorCode = if isANSIEnabled then U.showCursorCode else E.showCursorCode
+
+-- * Changing the title
+hSetTitle = if isANSIEnabled then U.hSetTitle else E.hSetTitle
+
+setTitleCode :: String -> String
+setTitleCode = if isANSIEnabled then U.setTitleCode else E.setTitleCode

--- a/System/Console/ANSI/Windows/Detect.hs
+++ b/System/Console/ANSI/Windows/Detect.hs
@@ -1,0 +1,65 @@
+{-# OPTIONS_HADDOCK hide #-}
+
+module System.Console.ANSI.Windows.Detect
+(
+    isANSIEnabled
+) where
+
+import Control.Exception (SomeException(..), throwIO, try)
+import Data.Bits ((.|.))
+import System.Console.ANSI.Windows.Foreign (ConsoleException(..), DWORD,
+    eNABLE_VIRTUAL_TERMINAL_PROCESSING, getConsoleMode, getStdHandle, HANDLE,
+    iNVALID_HANDLE_VALUE, nullHANDLE, setConsoleMode, sTD_OUTPUT_HANDLE)
+-- 'lookupEnv' is not available until base-4.6.0.0 (GHC 7.6.1)
+import System.Environment.Compat (lookupEnv)
+import System.IO.Unsafe (unsafePerformIO)
+
+-- This function assumes that once it is first established whether or not the
+-- Windows console is ANSI-enabled, that will not change.
+{-# NOINLINE isANSIEnabled #-}
+isANSIEnabled :: Bool
+isANSIEnabled = unsafePerformIO safeIsANSIEnabled
+
+-- This function takes the following approach. If the environment variable TERM
+-- exists and is not set to 'dumb' or 'msys' (see below), it assumes the console
+-- is ANSI-enabled. Otherwise, it tries to enable virtual terminal processing.
+-- If that fails, it assumes the console is not ANSI-enabled.
+--
+-- In Git Shell, if Command Prompt or PowerShell are used, the environment
+-- variable TERM is set to 'msys'. If 'Git Bash' (mintty) is used, TERM is set
+-- to 'xterm' (by default).
+safeIsANSIEnabled :: IO Bool
+safeIsANSIEnabled = do
+    result <- lookupEnv "TERM"
+    case result of
+        Just "dumb" -> return False
+        Just "msys" -> doesEnableANSIOutSucceed
+        Just _      -> return True
+        Nothing     -> doesEnableANSIOutSucceed
+
+-- This function returns whether or not an attempt to enable virtual terminal
+-- processing succeeded, in the IO monad.
+doesEnableANSIOutSucceed :: IO Bool
+doesEnableANSIOutSucceed = do
+    result <- try enableANSIOut :: IO (Either SomeException ())
+    case result of
+        Left _ -> return False
+        Right () -> return True
+
+-- This function tries to enable virtual terminal processing on the standard
+-- output and throws an exception if it cannot.
+enableANSIOut :: IO ()
+enableANSIOut = do
+    hOut <- getValidStdHandle sTD_OUTPUT_HANDLE
+    mOut <- getConsoleMode hOut
+    let mOut' = mOut .|. eNABLE_VIRTUAL_TERMINAL_PROCESSING
+    setConsoleMode hOut mOut'
+
+-- This function tries to get a valid standard handle and throws an exception if
+-- it cannot.
+getValidStdHandle :: DWORD -> IO HANDLE
+getValidStdHandle nStdHandle = do
+    h <- getStdHandle nStdHandle
+    if h == iNVALID_HANDLE_VALUE || h == nullHANDLE
+        then throwIO $ ConsoleException 6 -- Invalid Handle
+        else return h

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -34,12 +34,15 @@ Library
         
         Build-Depends:          base >= 4 && < 5
         if os(windows)
-                Build-Depends:          Win32 >= 2.0
+                Build-Depends:          base-compat >= 0.9.1
+                                      , Win32 >= 2.0
+                                      , process
                 Cpp-Options:            -DWINDOWS
                 Other-Modules:          System.Console.ANSI.Windows
-                                        System.Console.ANSI.Windows.Foreign
+                                        System.Console.ANSI.Windows.Detect        
                                         System.Console.ANSI.Windows.Emulator
                                         System.Console.ANSI.Windows.Emulator.Codes
+                                        System.Console.ANSI.Windows.Foreign
                                         -- NB: used for fallback by the emulator
                                         System.Console.ANSI.Unix
         else
@@ -64,12 +67,14 @@ Executable ansi-terminal-example
                                 System.Console.ANSI.Unix
 
         if os(windows)
-                Build-Depends:          Win32 >= 2.0
+                Build-Depends:          base-compat >= 0.9.1
+                                      , Win32 >= 2.0
                 Cpp-Options:            -DWINDOWS
                 Other-Modules:          System.Console.ANSI.Windows
-                                        System.Console.ANSI.Windows.Foreign
+                                        System.Console.ANSI.Windows.Detect
                                         System.Console.ANSI.Windows.Emulator
                                         System.Console.ANSI.Windows.Emulator.Codes
+                                        System.Console.ANSI.Windows.Foreign
         else
                 -- We assume any non-Windows platform is Unix
                 Build-Depends:          unix >= 2.3.0.0


### PR DESCRIPTION
This is the first time I have ever 'forked' anything, and I am not at all experienced with Haskell. I am conscious that over 100 other packages depend on `ansi-terminal` and I would not want to 'break' anything. This pull request is largely my experimenting - I do not expect it will be of much use to anyone.

With those caveats:

`module System.Info.Windows` is intended to be able to detect the version of Windows, making use of, and parsing, Windows' `VER` command's output. It relies on the `process` package.

`module System.Console.ANSI.Windows` chooses between the `U` (Unix - or, perhaps, 'universal') or `E` (emulated) functions, depending on `windowsVersion` via `isANSIVersion` - save for the `SetTitle` (where a control code sequence is not used) and `ScrollPageUp\Down` (where Microsoft does not appear to have implemented the code sequences, despite its documentation), where the `E` functions are always used.

In `Example.hs`, I slowed down the `pause` (because examples were going past too quickly for me to follow). I also swapped the order in `resetScreen` because filling the screen with spaces first before resetting to the default was giving unexpected results when  `SetUnderlining DoubleUnderline` did nothing after `SetUnderlining SingleUnderline` had previously been applied in the examples.

I used `stack` to build and test (on a Windows 10 PC using Command Prompt only - no other terminals or OSs have been tried), so I amended `.gitignore` to include ignoring the configuration file and the working folder.

In the `.cabal` file, I added `process` and `System.Info.Windows`. `stack` complained that `other-modules` were missing when it built the example, so I added them too. I've bumped the minor version up one, to 0.6.2.4.
