### PR TITLE
Make Codes visible (for Windows) 

### DIFF
--- a/System/Console/ANSI/Codes.hs
+++ b/System/Console/ANSI/Codes.hs
@@ -1,0 +1,161 @@
+-- | Functions that return 'String' values containing codes in accordance with:
+-- (1) standard ECMA-48 Control Functions for Coded Character Sets (5th edition,
+-- 1991); or (2) in the case of 'setTitleCode', the XTerm control sequence.
+--
+-- The reference used for the codes in this module was
+-- <http://en.wikipedia.org/wiki/ANSI_escape_sequences>.
+--
+-- If module "System.Console.ANSI" is also imported, this module is intended to
+-- be imported qualified, to avoid name clashes with functions which return \"\"
+-- when Windows ANSI terminal support is emulated. e.g.
+--
+-- > import qualified System.Console.ANSI.Codes as ANSI
+--
+module System.Console.ANSI.Codes
+    (
+      -- * Basic data types
+      module System.Console.ANSI.Types
+
+      -- * Cursor movement by character
+    , cursorUpCode, cursorDownCode, cursorForwardCode, cursorBackwardCode
+
+      -- * Cursor movement by line
+    , cursorUpLineCode, cursorDownLineCode
+
+      -- * Directly changing cursor position
+    , setCursorColumnCode, setCursorPositionCode
+
+      -- * Clearing parts of the screen
+    , clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode
+    , clearScreenCode, clearFromCursorToLineEndCode
+    , clearFromCursorToLineBeginningCode, clearLineCode
+
+      -- * Scrolling the screen
+    , scrollPageUpCode, scrollPageDownCode
+
+      -- * Select Graphic Rendition mode: colors and other whizzy stuff
+    , setSGRCode
+
+      -- * Cursor visibilty changes
+    , hideCursorCode, showCursorCode
+
+      -- * Changing the title
+      -- | Thanks to Brandon S. Allbery and Curt Sampson for pointing me in the
+      -- right direction on xterm title setting on haskell-cafe. The "0"
+      -- signifies that both the title and "icon" text should be set: i.e. the
+      -- text for the window in the Start bar (or similar) as well as that in
+      -- the actual window title. This is chosen for consistent behaviour
+      -- between Unixes and Windows.
+    , setTitleCode
+
+      -- * Utilities
+    , colorToCode, csi, sgrToCode
+    ) where
+
+import Data.List (intersperse)
+import System.Console.ANSI.Types
+
+-- | 'csi' @parameters controlFunction@, where @parameters@ is a list of 'Int',
+-- returns the control sequence comprising the control function CONTROL
+-- SEQUENCE INTRODUCER (CSI) followed by the parameter(s) (separated by \';\')
+-- and ending with the @controlFunction@ character(s) that identifies the
+-- control function.
+csi :: [Int]  -- ^ List of parameters for the control sequence
+    -> String -- ^ Character(s) that identify the control function
+    -> String
+csi args code = "\ESC[" ++ concat (intersperse ";" (map show args)) ++ code
+
+-- | 'colorToCode' @color@ returns the 0-based index of the color (one of the
+-- eight colors in the standard).
+colorToCode :: Color -> Int
+colorToCode color = case color of
+    Black   -> 0
+    Red     -> 1
+    Green   -> 2
+    Yellow  -> 3
+    Blue    -> 4
+    Magenta -> 5
+    Cyan    -> 6
+    White   -> 7
+
+-- | 'sgrToCode' @sgr@ returns the parameter of the SELECT GRAPHIC RENDITION
+-- (SGR) aspect identified by @sgr@.
+sgrToCode :: SGR -- ^ The SGR aspect
+          -> Int
+sgrToCode sgr = case sgr of
+    Reset -> 0
+    SetConsoleIntensity intensity -> case intensity of
+        BoldIntensity   -> 1
+        FaintIntensity  -> 2
+        NormalIntensity -> 22
+    SetItalicized True  -> 3
+    SetItalicized False -> 23
+    SetUnderlining underlining -> case underlining of
+        SingleUnderline -> 4
+        DoubleUnderline -> 21
+        NoUnderline     -> 24
+    SetBlinkSpeed blink_speed -> case blink_speed of
+        SlowBlink   -> 5
+        RapidBlink  -> 6
+        NoBlink     -> 25
+    SetVisible False -> 8
+    SetVisible True  -> 28
+    SetSwapForegroundBackground True  -> 7
+    SetSwapForegroundBackground False -> 27
+    SetColor Foreground Dull color  -> 30 + colorToCode color
+    SetColor Foreground Vivid color -> 90 + colorToCode color
+    SetColor Background Dull color  -> 40 + colorToCode color
+    SetColor Background Vivid color -> 100 + colorToCode color
+
+cursorUpCode, cursorDownCode, cursorForwardCode, cursorBackwardCode :: Int -- ^ Number of lines or characters to move
+                                                                    -> String
+cursorUpCode n = csi [n] "A"
+cursorDownCode n = csi [n] "B"
+cursorForwardCode n = csi [n] "C"
+cursorBackwardCode n = csi [n] "D"
+
+cursorDownLineCode, cursorUpLineCode :: Int -- ^ Number of lines to move
+                                     -> String
+cursorDownLineCode n = csi [n] "E"
+cursorUpLineCode n = csi [n] "F"
+
+setCursorColumnCode :: Int -- ^ 0-based column to move to
+                    -> String
+setCursorColumnCode n = csi [n + 1] "G"
+
+setCursorPositionCode :: Int -- ^ 0-based row to move to
+                      -> Int -- ^ 0-based column to move to
+                      -> String
+setCursorPositionCode n m = csi [n + 1, m + 1] "H"
+
+clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode, clearScreenCode :: String
+clearFromCursorToLineEndCode, clearFromCursorToLineBeginningCode, clearLineCode :: String
+
+clearFromCursorToScreenEndCode = csi [0] "J"
+clearFromCursorToScreenBeginningCode = csi [1] "J"
+clearScreenCode = csi [2] "J"
+clearFromCursorToLineEndCode = csi [0] "K"
+clearFromCursorToLineBeginningCode = csi [1] "K"
+clearLineCode = csi [2] "K"
+
+scrollPageUpCode, scrollPageDownCode :: Int -- ^ Number of lines to scroll by
+                                     -> String
+scrollPageUpCode n = csi [n] "S"
+scrollPageDownCode n = csi [n] "T"
+
+setSGRCode :: [SGR] -- ^ Commands: these will typically be applied on top of the
+                    -- current console SGR mode. An empty list of commands is
+                    -- equivalent to the list @[Reset]@. Commands are applied
+                    -- left to right.
+           -> String
+setSGRCode sgrs = csi (map sgrToCode sgrs) "m"
+
+hideCursorCode, showCursorCode :: String
+hideCursorCode = csi [] "?25l"
+showCursorCode = csi [] "?25h"
+
+
+-- | XTerm control sequence to set the Icon Name and Window Title.
+setTitleCode :: String -- ^ New Icon Name and Window Title
+             -> String
+setTitleCode title = "\ESC]0;" ++ filter (/= '\007') title ++ "\007"

--- a/System/Console/ANSI/Types.hs
+++ b/System/Console/ANSI/Types.hs
@@ -1,4 +1,14 @@
-module System.Console.ANSI.Common where
+-- | Types used to represent SELECT GRAPHIC RENDITION (SGR) aspects.
+module System.Console.ANSI.Types
+    (
+      SGR (..)
+    , ConsoleLayer (..)
+    , Color (..)
+    , ColorIntensity (..)
+    , ConsoleIntensity (..)
+    , Underlining (..)
+    , BlinkSpeed (..)
+    ) where
 
 import Data.Ix
 

--- a/System/Console/ANSI/Unix.hs
+++ b/System/Console/ANSI/Unix.hs
@@ -3,123 +3,37 @@ module System.Console.ANSI.Unix (
 #include "Exports-Include.hs"
     ) where
 
-import System.Console.ANSI.Common
-
-import System.IO
-
-import Data.List
-
+import System.Console.ANSI.Codes
+import System.Console.ANSI.Types
+import System.IO (Handle, hIsTerminalDevice, hPutStr, stdout)
 
 #include "Common-Include.hs"
-
-
--- | The reference I used for the ANSI escape characters in this module was <http://en.wikipedia.org/wiki/ANSI_escape_sequences>.
-csi :: [Int] -> String -> String
-csi args code = "\ESC[" ++ concat (intersperse ";" (map show args)) ++ code
-
-colorToCode :: Color -> Int
-colorToCode color = case color of
-    Black   -> 0
-    Red     -> 1
-    Green   -> 2
-    Yellow  -> 3
-    Blue    -> 4
-    Magenta -> 5
-    Cyan    -> 6
-    White   -> 7
-
-sgrToCode :: SGR -> Int
-sgrToCode sgr = case sgr of
-    Reset -> 0
-    SetConsoleIntensity intensity -> case intensity of
-        BoldIntensity   -> 1
-        FaintIntensity  -> 2
-        NormalIntensity -> 22
-    SetItalicized True  -> 3
-    SetItalicized False -> 23
-    SetUnderlining underlining -> case underlining of
-        SingleUnderline -> 4
-        DoubleUnderline -> 21
-        NoUnderline     -> 24
-    SetBlinkSpeed blink_speed -> case blink_speed of
-        SlowBlink   -> 5
-        RapidBlink  -> 6
-        NoBlink     -> 25
-    SetVisible False -> 8
-    SetVisible True  -> 28
-    SetSwapForegroundBackground True  -> 7
-    SetSwapForegroundBackground False -> 27
-    SetColor Foreground Dull color  -> 30 + colorToCode color
-    SetColor Foreground Vivid color -> 90 + colorToCode color
-    SetColor Background Dull color  -> 40 + colorToCode color
-    SetColor Background Vivid color -> 100 + colorToCode color
-
-
-cursorUpCode n = csi [n] "A"
-cursorDownCode n = csi [n] "B"
-cursorForwardCode n = csi [n] "C"
-cursorBackwardCode n = csi [n] "D"
 
 hCursorUp h n = hPutStr h $ cursorUpCode n
 hCursorDown h n = hPutStr h $ cursorDownCode n
 hCursorForward h n = hPutStr h $ cursorForwardCode n
 hCursorBackward h n = hPutStr h $ cursorBackwardCode n
 
-
-cursorDownLineCode n = csi [n] "E"
-cursorUpLineCode n = csi [n] "F"
-
 hCursorDownLine h n = hPutStr h $ cursorDownLineCode n
 hCursorUpLine h n = hPutStr h $ cursorUpLineCode n
 
-
-setCursorColumnCode n = csi [n + 1] "G"
-setCursorPositionCode n m = csi [n + 1, m + 1] "H"
-
 hSetCursorColumn h n = hPutStr h $ setCursorColumnCode n
 hSetCursorPosition h n m = hPutStr h $ setCursorPositionCode n m
-
-
-clearFromCursorToScreenEndCode = csi [0] "J"
-clearFromCursorToScreenBeginningCode = csi [1] "J"
-clearScreenCode = csi [2] "J"
 
 hClearFromCursorToScreenEnd h = hPutStr h clearFromCursorToScreenEndCode
 hClearFromCursorToScreenBeginning h = hPutStr h clearFromCursorToScreenBeginningCode
 hClearScreen h = hPutStr h clearScreenCode
 
-
-clearFromCursorToLineEndCode = csi [0] "K"
-clearFromCursorToLineBeginningCode = csi [1] "K"
-clearLineCode = csi [2] "K"
-
 hClearFromCursorToLineEnd h = hPutStr h clearFromCursorToLineEndCode
 hClearFromCursorToLineBeginning h = hPutStr h clearFromCursorToLineBeginningCode
 hClearLine h = hPutStr h clearLineCode
 
-
-scrollPageUpCode n = csi [n] "S"
-scrollPageDownCode n = csi [n] "T"
-
 hScrollPageUp h n = hPutStr h $ scrollPageUpCode n
 hScrollPageDown h n = hPutStr h $ scrollPageDownCode n
 
-
-setSGRCode sgrs = csi (map sgrToCode sgrs) "m"
-
 hSetSGR h sgrs = hPutStr h $ setSGRCode sgrs
-
-
-hideCursorCode = csi [] "?25l"
-showCursorCode = csi [] "?25h"
 
 hHideCursor h = hPutStr h hideCursorCode
 hShowCursor h = hPutStr h showCursorCode
-
-
--- | Thanks to Brandon S. Allbery and Curt Sampson for pointing me in the right direction on xterm title setting on haskell-cafe.
--- The "0" signifies that both the title and "icon" text should be set: i.e. the text for the window in the Start bar (or similar)
--- as well as that in the actual window title.  This is chosen for consistent behaviour between Unixes and Windows.
-setTitleCode title = "\ESC]0;" ++ filter (/= '\007') title ++ "\007"
 
 hSetTitle h title = hPutStr h $ setTitleCode title

--- a/System/Console/ANSI/Windows.hs
+++ b/System/Console/ANSI/Windows.hs
@@ -3,5 +3,5 @@ module System.Console.ANSI.Windows (
 #include "Exports-Include.hs"
     ) where
 
-import System.Console.ANSI.Common
+import System.Console.ANSI.Types
 import System.Console.ANSI.Windows.Emulator

--- a/System/Console/ANSI/Windows/Emulator/Codes.hs
+++ b/System/Console/ANSI/Windows/Emulator/Codes.hs
@@ -1,0 +1,83 @@
+{-# OPTIONS_HADDOCK hide #-}
+
+module System.Console.ANSI.Windows.Emulator.Codes
+    (
+      -- * Cursor movement by character
+      cursorUpCode, cursorDownCode, cursorForwardCode, cursorBackwardCode
+
+      -- * Cursor movement by line
+    , cursorUpLineCode, cursorDownLineCode
+
+      -- * Directly changing cursor position
+    , setCursorColumnCode, setCursorPositionCode
+
+      -- * Clearing parts of the screen
+    , clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode
+    , clearScreenCode, clearFromCursorToLineEndCode
+    , clearFromCursorToLineBeginningCode, clearLineCode
+
+      -- * Scrolling the screen
+    , scrollPageUpCode, scrollPageDownCode
+
+      -- * Select Graphic Rendition mode: colors and other whizzy stuff
+    , setSGRCode
+
+      -- * Cursor visibilty changes
+    , hideCursorCode, showCursorCode
+
+      -- * Changing the title
+    , setTitleCode
+    ) where
+
+import System.Console.ANSI.Types
+
+cursorUpCode, cursorDownCode, cursorForwardCode, cursorBackwardCode :: Int -- ^ Number of lines or characters to move
+                                                                    -> String
+cursorUpCode _       = ""
+cursorDownCode _     = ""
+cursorForwardCode _  = ""
+cursorBackwardCode _ = ""
+
+cursorDownLineCode, cursorUpLineCode :: Int -- ^ Number of lines to move
+                                     -> String
+cursorDownLineCode _ = ""
+cursorUpLineCode _   = ""
+
+setCursorColumnCode :: Int -- ^ 0-based column to move to
+                    -> String
+setCursorColumnCode _ = ""
+
+setCursorPositionCode :: Int -- ^ 0-based row to move to
+                      -> Int -- ^ 0-based column to move to
+                      -> String
+setCursorPositionCode _ _ = ""
+
+clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode, clearScreenCode :: String
+clearFromCursorToLineEndCode, clearFromCursorToLineBeginningCode, clearLineCode :: String
+
+clearFromCursorToScreenEndCode       = ""
+clearFromCursorToScreenBeginningCode = ""
+clearScreenCode                      = ""
+clearFromCursorToLineEndCode         = ""
+clearFromCursorToLineBeginningCode   = ""
+clearLineCode                        = ""
+
+scrollPageUpCode, scrollPageDownCode :: Int -- ^ Number of lines to scroll by
+                                     -> String
+scrollPageUpCode _   = ""
+scrollPageDownCode _ = ""
+
+setSGRCode :: [SGR] -- ^ Commands: these will typically be applied on top of the
+                    -- current console SGR mode. An empty list of commands is
+                    -- equivalent to the list @[Reset]@. Commands are applied
+                    -- left to right.
+           -> String
+setSGRCode _ = ""
+
+hideCursorCode, showCursorCode :: String
+hideCursorCode = ""
+showCursorCode = ""
+
+setTitleCode :: String -- ^ New title
+             -> String
+setTitleCode _ = ""

--- a/System/Console/ANSI/Windows/Foreign.hs
+++ b/System/Console/ANSI/Windows/Foreign.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_HADDOCK hide #-}
+
 -- | "System.Win32.Console" is really very impoverished, so I have had to do all the FFI myself.
 module System.Console.ANSI.Windows.Foreign (
         -- Re-exports from Win32.Types

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -17,7 +17,6 @@ Extra-Source-Files:     includes/Common-Include.hs
                         CHANGELOG.md
                         README.md
 
-
 Source-repository head
   type:     git
   location: git://github.com/feuerbach/ansi-terminal.git
@@ -28,8 +27,8 @@ Flag Example
 
 Library
         Exposed-Modules:        System.Console.ANSI
-        
-        Other-Modules:          System.Console.ANSI.Common
+                                System.Console.ANSI.Types
+                                System.Console.ANSI.Codes
         
         Include-Dirs:           includes
         
@@ -40,6 +39,7 @@ Library
                 Other-Modules:          System.Console.ANSI.Windows
                                         System.Console.ANSI.Windows.Foreign
                                         System.Console.ANSI.Windows.Emulator
+                                        System.Console.ANSI.Windows.Emulator.Codes
                                         -- NB: used for fallback by the emulator
                                         System.Console.ANSI.Unix
         else
@@ -57,25 +57,29 @@ Executable ansi-terminal-example
         Main-Is:                System/Console/ANSI/Example.hs
         
         Include-Dirs:           includes
-        
+
+        Other-Modules:          System.Console.ANSI
+                                System.Console.ANSI.Codes
+                                System.Console.ANSI.Types
+                                System.Console.ANSI.Unix
+
         if os(windows)
                 Build-Depends:          Win32 >= 2.0
                 Cpp-Options:            -DWINDOWS
                 Other-Modules:          System.Console.ANSI.Windows
                                         System.Console.ANSI.Windows.Foreign
                                         System.Console.ANSI.Windows.Emulator
+                                        System.Console.ANSI.Windows.Emulator.Codes
         else
                 -- We assume any non-Windows platform is Unix
                 Build-Depends:          unix >= 2.3.0.0
                 Cpp-Options:            -DUNIX
-                Other-Modules:          System.Console.ANSI.Unix
-        
-        
+
         Build-Depends:          base >= 4 && < 5
         Extensions:             CPP
                                 ForeignFunctionInterface
-        
+
         Ghc-Options:            -Wall
-        
+
         if !flag(example)
                 Buildable:              False

--- a/includes/Common-Include.hs
+++ b/includes/Common-Include.hs
@@ -8,37 +8,25 @@ hCursorUp, hCursorDown, hCursorForward, hCursorBackward :: Handle
                                                         -> IO ()
 cursorUp, cursorDown, cursorForward, cursorBackward :: Int -- ^ Number of lines or characters to move
                                                     -> IO ()
-cursorUpCode, cursorDownCode, cursorForwardCode, cursorBackwardCode :: Int -- ^ Number of lines or characters to move
-                                                                    -> String
-
 cursorUp = hCursorUp stdout
 cursorDown = hCursorDown stdout
 cursorForward = hCursorForward stdout
 cursorBackward = hCursorBackward stdout
-
 
 hCursorDownLine, hCursorUpLine :: Handle
                                -> Int -- ^ Number of lines to move
                                -> IO ()
 cursorDownLine, cursorUpLine :: Int -- ^ Number of lines to move
                              -> IO ()
-cursorDownLineCode, cursorUpLineCode :: Int -- ^ Number of lines to move
-                                     -> String
-
 cursorDownLine = hCursorDownLine stdout
 cursorUpLine = hCursorUpLine stdout
-
 
 hSetCursorColumn :: Handle
                  -> Int -- ^ 0-based column to move to
                  -> IO ()
 setCursorColumn :: Int -- ^ 0-based column to move to
                 -> IO ()
-setCursorColumnCode :: Int -- ^ 0-based column to move to
-                    -> String
-
 setCursorColumn = hSetCursorColumn stdout
-
 
 hSetCursorPosition :: Handle
                    -> Int -- ^ 0-based row to move to
@@ -47,32 +35,22 @@ hSetCursorPosition :: Handle
 setCursorPosition :: Int -- ^ 0-based row to move to
                   -> Int -- ^ 0-based column to move to
                   -> IO ()
-setCursorPositionCode :: Int -- ^ 0-based row to move to
-                      -> Int -- ^ 0-based column to move to
-                      -> String
-
 setCursorPosition = hSetCursorPosition stdout
-
 
 hClearFromCursorToScreenEnd, hClearFromCursorToScreenBeginning, hClearScreen :: Handle
                                                                              -> IO ()
 clearFromCursorToScreenEnd, clearFromCursorToScreenBeginning, clearScreen :: IO ()
-clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode, clearScreenCode :: String
-
 clearFromCursorToScreenEnd = hClearFromCursorToScreenEnd stdout
 clearFromCursorToScreenBeginning = hClearFromCursorToScreenBeginning stdout
 clearScreen = hClearScreen stdout
 
-
 hClearFromCursorToLineEnd, hClearFromCursorToLineBeginning, hClearLine :: Handle
                                                                        -> IO ()
 clearFromCursorToLineEnd, clearFromCursorToLineBeginning, clearLine :: IO ()
-clearFromCursorToLineEndCode, clearFromCursorToLineBeginningCode, clearLineCode :: String
 
 clearFromCursorToLineEnd = hClearFromCursorToLineEnd stdout
 clearFromCursorToLineBeginning = hClearFromCursorToLineBeginning stdout
 clearLine = hClearLine stdout
-
 
 -- | Scroll the displayed information up or down the terminal: not widely supported
 hScrollPageUp, hScrollPageDown :: Handle
@@ -82,12 +60,8 @@ hScrollPageUp, hScrollPageDown :: Handle
 scrollPageUp, scrollPageDown :: Int -- ^ Number of lines to scroll by
                              -> IO ()
 -- | Scroll the displayed information up or down the terminal: not widely supported
-scrollPageUpCode, scrollPageDownCode :: Int -- ^ Number of lines to scroll by
-                                     -> String
-
 scrollPageUp = hScrollPageUp stdout
 scrollPageDown = hScrollPageDown stdout
-
 
 -- | Set the Select Graphic Rendition mode
 hSetSGR :: Handle
@@ -101,22 +75,13 @@ setSGR :: [SGR] -- ^ Commands: these will typically be applied on top of the cur
                 -- left to right.
        -> IO ()
 -- | Set the Select Graphic Rendition mode
-setSGRCode :: [SGR] -- ^ Commands: these will typically be applied on top of the current console SGR mode.
-                    -- An empty list of commands is equivalent to the list @[Reset]@. Commands are applied
-                    -- left to right.
-           -> String
-
 setSGR = hSetSGR stdout
-
 
 hHideCursor, hShowCursor :: Handle
                          -> IO ()
 hideCursor, showCursor :: IO ()
-hideCursorCode, showCursorCode :: String
-
 hideCursor = hHideCursor stdout
 showCursor = hShowCursor stdout
-
 
 -- | Set the terminal window title
 hSetTitle :: Handle
@@ -125,10 +90,6 @@ hSetTitle :: Handle
 -- | Set the terminal window title
 setTitle :: String -- ^ New title
          -> IO ()
--- | Set the terminal window title
-setTitleCode :: String -- ^ New title
-             -> String
-
 setTitle = hSetTitle stdout
 
 -- | Use heuristics to determine whether the functions defined in this

--- a/includes/Exports-Include.hs
+++ b/includes/Exports-Include.hs
@@ -1,5 +1,5 @@
 -- * Basic data types
-module System.Console.ANSI.Common,
+module System.Console.ANSI.Types,
 
 -- * Cursor movement by character
 cursorUp, cursorDown, cursorForward, cursorBackward,


### PR DESCRIPTION
This pull request seeks to make the functions that return ANSI code strings visible, on both non-Windows and Windows versions of the library. The functionality of module `System.Console.ANSI` is unaffected.

Hidden module `System.Console.ANSI.Common` is replaced by visible modules `System.Console.ANSI.Types` and `System.Console.ANSI.Codes`.

The types are in `System.Console.ANSI.Types`. The functions that return ANSI code strings are in `System.Console.ANSI.Codes`. The corresponding type signatures, that were in `Common-Include.hs`, are also moved to `System.Console.ANSI.Codes`. For convenience, `System.Console.ANSI.Codes` also re-exports `System.Console.ANSI.Types`.

As those type signatures are no longer in `Common-Include.hs`, copies have put in module `System.Console.ANSI.Windows.Emulator.Codes`, for use in `System.Console.ANSI.Windows.Emulator`. The similarly named functions that return `""` in `System.Console.ANSI.Windows.Emulator` are also moved to `System.Console.ANSI.Windows.Emulator.Codes`, so those functions and their signatures are now together in the same module.

Further, the three code-related functions that were in `System.Console.ANSI.Unix` (`colorToCode`, `csi` and `sgrToCode`) are moved to `System.Console.ANSI.Codes`, and exported as utility functions.

Haddock documentation is added (or suppressed, where applicable).

I have done some testing on: Windows 7 (Command Prompt), Windows 10 (Command Prompt and PowerShell) and OS X 10.11.4 (Terminal). This comprised: (1) building with the example (`stack build --flag ansi-terminal:Example`) and executing the example (`ansi-terminal-example`) and comparing the output with that of the existing version of the library; and (2) in `stack ghci` examining the return of a sample of the code functions that return a `String` value.