### PR TITLE
Add save, restore, report cursor

### DIFF
--- a/System/Console/ANSI/Codes.hs
+++ b/System/Console/ANSI/Codes.hs
@@ -25,6 +25,9 @@ module System.Console.ANSI.Codes
       -- * Directly changing cursor position
     , setCursorColumnCode, setCursorPositionCode
 
+      -- * Saving, restoring and reporting cursor position
+    , saveCursorCode, restoreCursorCode, reportCursorPositionCode
+
       -- * Clearing parts of the screen
     , clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode
     , clearScreenCode, clearFromCursorToLineEndCode
@@ -133,6 +136,11 @@ setCursorPositionCode :: Int -- ^ 0-based row to move to
                       -> Int -- ^ 0-based column to move to
                       -> String
 setCursorPositionCode n m = csi [n + 1, m + 1] "H"
+
+saveCursorCode, restoreCursorCode, reportCursorPositionCode :: String
+saveCursorCode = "\ESC7"
+restoreCursorCode = "\ESC8"
+reportCursorPositionCode = csi [] "6n"
 
 clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode, clearScreenCode :: String
 clearFromCursorToLineEndCode, clearFromCursorToLineBeginningCode, clearLineCode :: String

--- a/System/Console/ANSI/Example.hs
+++ b/System/Console/ANSI/Example.hs
@@ -14,11 +14,13 @@ examples :: [IO ()]
 examples = [ cursorMovementExample
            , lineChangeExample
            , setCursorPositionExample
+           , saveRestoreCursorExample
            , clearExample
            , scrollExample
            , sgrExample
            , cursorVisibilityExample
            , titleExample
+           , reportCursorPositionExample
            ]
 
 main :: IO ()
@@ -46,25 +48,25 @@ cursorMovementExample = do
     pause
     -- Line One
     -- Line Two
-    
+
     cursorUp 1
     putStr " - Extras"
     pause
     -- Line One - Extras
     -- Line Two
-    
+
     cursorBackward 2
     putStr "zz"
     pause
     -- Line One - Extrzz
     -- Line Two
-    
+
     cursorForward 2
     putStr "- And More"
     pause
     -- Line One - Extrzz  - And More
     -- Line Two
-    
+
     cursorDown 1
     putStr "Disconnected"
     pause
@@ -78,13 +80,13 @@ lineChangeExample = do
     pause
     -- Line One
     -- Line Two
-    
+
     cursorUpLine 1
     putStr "New Line One"
     pause
     -- New Line One
     -- Line Two
-    
+
     cursorDownLine 1
     putStr "New Line Two"
     pause
@@ -98,24 +100,45 @@ setCursorPositionExample = do
     pause
     -- Line One
     -- Line Two
-    
+
     setCursorPosition 0 5
     putStr "Foo"
     pause
     -- Line Foo
     -- Line Two
-    
+
     setCursorPosition 1 5
     putStr "Bar"
     pause
     -- Line Foo
     -- Line Bar
-    
+
     setCursorColumn 1
     putStr "oaf"
     pause
     -- Line Foo
     -- Loaf Bar
+
+saveRestoreCursorExample :: IO ()
+saveRestoreCursorExample = do
+    putStr "Start sentence ..."
+    pause
+    -- Start sentence ...
+
+    saveCursor
+    setCursorPosition 2 3
+    putStr "SPLASH!"
+    pause
+    -- Start sentence ...
+    --
+    --    SPLASH!
+
+    restoreCursor
+    putStr " end sentence, uninterrupted."
+    pause
+    -- Start sentence ... end sentence, uninterrupted
+    --
+    --    SPLASH!
 
 clearExample :: IO ()
 clearExample = do
@@ -124,50 +147,50 @@ clearExample = do
     pause
     -- Line One
     -- Line Two
-    
+
     setCursorPosition 0 4
     clearFromCursorToScreenEnd
     pause
     -- Line
-    
-    
+
+
     resetScreen
     putStrLn "Line One"
     putStrLn "Line Two"
     pause
     -- Line One
     -- Line Two
-    
+
     setCursorPosition 1 4
     clearFromCursorToScreenBeginning
     pause
     --
     --     Two
-    
-    
+
+
     resetScreen
     putStrLn "Line One"
     putStrLn "Line Two"
     pause
     -- Line One
     -- Line Two
-    
+
     setCursorPosition 0 4
     clearFromCursorToLineEnd
     pause
     -- Line
     -- Line Two
-    
+
     setCursorPosition 1 4
     clearFromCursorToLineBeginning
     pause
     -- Line
     --      Two
-    
+
     clearLine
     pause
     -- Line
-    
+
     clearScreen
     pause
     --
@@ -181,7 +204,7 @@ scrollExample = do
     -- Line One
     -- Line Two
     -- Line Three
-    
+
     scrollPageDown 2
     pause
     --
@@ -189,7 +212,7 @@ scrollExample = do
     -- Line One
     -- Line Two
     -- Line Three
-    
+
     scrollPageUp 3
     pause
     -- Line Two
@@ -207,7 +230,7 @@ sgrExample = do
                 putStrLn (show color)
             pause
     -- All the colors, 4 times in sequence
-    
+
     let named_styles = [ (SetConsoleIntensity BoldIntensity, "Bold")
                        , (SetConsoleIntensity FaintIntensity, "Faint")
                        , (SetConsoleIntensity NormalIntensity, "Normal")
@@ -228,16 +251,16 @@ sgrExample = do
               putStrLn name
               pause
     -- Text describing a style displayed in that style in sequence
-    
+
     setSGR [SetColor Foreground Vivid Red]
     setSGR [SetColor Background Vivid Blue]
-    
+
     clearScreen >> setCursorPosition 0 0
     setSGR [SetSwapForegroundBackground False]
     putStr "Red-On-Blue"
     pause
     -- Red-On-Blue
-    
+
     clearScreen >> setCursorPosition 0 0
     setSGR [SetSwapForegroundBackground True]
     putStr "Blue-On-Red"
@@ -249,11 +272,11 @@ cursorVisibilityExample = do
     putStr "Cursor Demo"
     pause
     -- Cursor Demo|
-    
+
     hideCursor
     pause
     -- Cursor Demo
-    
+
     showCursor
     pause
     -- Cursor Demo|
@@ -265,9 +288,16 @@ titleExample = do
     -- ~/foo/ - ansi-terminal-ex - 83x70
     ------------------------------------
     -- Title Demo
-    
+
     setTitle "Yup, I'm a new title!"
     pause
     -- Yup, I'm a new title! - ansi-terminal-ex - 83x70
     ---------------------------------------------------
     -- Title Demo
+
+reportCursorPositionExample :: IO ()
+reportCursorPositionExample = do
+    putStr "Report cursor position here:"
+    pause
+    reportCursorPosition
+    putStrLn " (1st row, 29th column) to stdin, as CSI 1 ; 29 R."

--- a/System/Console/ANSI/Unix.hs
+++ b/System/Console/ANSI/Unix.hs
@@ -21,6 +21,10 @@ hCursorUpLine h n = hPutStr h $ cursorUpLineCode n
 hSetCursorColumn h n = hPutStr h $ setCursorColumnCode n
 hSetCursorPosition h n m = hPutStr h $ setCursorPositionCode n m
 
+hSaveCursor h = hPutStr h saveCursorCode
+hRestoreCursor h = hPutStr h restoreCursorCode
+hReportCursorPosition h = hPutStr h reportCursorPositionCode
+
 hClearFromCursorToScreenEnd h = hPutStr h clearFromCursorToScreenEndCode
 hClearFromCursorToScreenBeginning h = hPutStr h clearFromCursorToScreenBeginningCode
 hClearScreen h = hPutStr h clearScreenCode

--- a/System/Console/ANSI/Windows.hs
+++ b/System/Console/ANSI/Windows.hs
@@ -69,6 +69,22 @@ setCursorPositionCode :: Int -> Int -> String
 setCursorPositionCode = nativeOrEmulated
     U.setCursorPositionCode E.setCursorPositionCode
 
+-- * Saving, restoring and reporting cursor position
+hSaveCursor = nativeOrEmulated U.hSaveCursor E.hSaveCursor
+hRestoreCursor = nativeOrEmulated U.hRestoreCursor E.hRestoreCursor
+hReportCursorPosition = nativeOrEmulated
+    U.hReportCursorPosition E.hReportCursorPosition
+
+saveCursorCode :: String
+saveCursorCode = nativeOrEmulated U.saveCursorCode E.saveCursorCode
+
+restoreCursorCode :: String
+restoreCursorCode = nativeOrEmulated U.restoreCursorCode E.restoreCursorCode
+
+reportCursorPositionCode :: String
+reportCursorPositionCode = nativeOrEmulated
+    U.reportCursorPositionCode E.reportCursorPositionCode
+
 -- * Clearing parts of the screen
 hClearFromCursorToScreenEnd = nativeOrEmulatedWithDefault
     U.hClearFromCursorToScreenEnd E.hClearFromCursorToScreenEnd

--- a/System/Console/ANSI/Windows/Emulator/Codes.hs
+++ b/System/Console/ANSI/Windows/Emulator/Codes.hs
@@ -11,6 +11,9 @@ module System.Console.ANSI.Windows.Emulator.Codes
       -- * Directly changing cursor position
     , setCursorColumnCode, setCursorPositionCode
 
+      -- * Saving, restoring and reporting cursor position
+    , saveCursorCode, restoreCursorCode, reportCursorPositionCode
+
       -- * Clearing parts of the screen
     , clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode
     , clearScreenCode, clearFromCursorToLineEndCode
@@ -51,6 +54,11 @@ setCursorPositionCode :: Int -- ^ 0-based row to move to
                       -> Int -- ^ 0-based column to move to
                       -> String
 setCursorPositionCode _ _ = ""
+
+saveCursorCode, restoreCursorCode, reportCursorPositionCode :: String
+saveCursorCode = ""
+restoreCursorCode = ""
+reportCursorPositionCode = ""
 
 clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode, clearScreenCode :: String
 clearFromCursorToLineEndCode, clearFromCursorToLineBeginningCode, clearLineCode :: String

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -3,8 +3,9 @@ Version:             0.7
 Cabal-Version:       >= 1.6
 Category:            User Interfaces
 Synopsis:            Simple ANSI terminal support, with Windows compatibility
-Description:         ANSI terminal support for Haskell: allows cursor movement, screen clearing, color output, showing or hiding the cursor, and
-                     changing the title. Works on UNIX and Windows.
+Description:         ANSI terminal support for Haskell: allows cursor movement,
+                     screen clearing, color output, showing or hiding the
+                     cursor, and changing the title. Works on UNIX and Windows.
 License:             BSD3
 License-File:        LICENSE
 Author:              Max Bolingbroke
@@ -38,6 +39,7 @@ Library
                               , colour
         if os(windows)
                 Build-Depends:          base-compat >= 0.9.1
+                                      , containers
                                       , Win32 >= 2.0
                                       , process
                 Cpp-Options:            -DWINDOWS
@@ -70,6 +72,7 @@ Executable ansi-terminal-example
 
         if os(windows)
                 Build-Depends:          base-compat >= 0.9.1
+                                      , containers
                                       , Win32 >= 2.0
                 Cpp-Options:            -DWINDOWS
                 Other-Modules:          System.Console.ANSI.Windows

--- a/includes/Common-Include.hs
+++ b/includes/Common-Include.hs
@@ -37,6 +37,23 @@ setCursorPosition :: Int -- ^ 0-based row to move to
                   -> IO ()
 setCursorPosition = hSetCursorPosition stdout
 
+hSaveCursor, hRestoreCursor, hReportCursorPosition :: Handle -> IO ()
+
+-- | Save the cursor position in memory. The only way to access the saved value
+-- is with the `restoreCursor` command.
+saveCursor :: IO ()
+-- | Restore the cursor position from memory. There will be no value saved in
+-- memory until the first use of the `saveCursor` command.
+restoreCursor :: IO ()
+-- | Emit the cursor position into the console input stream, immediately after
+-- being recognised on the output stream, as:
+-- @ESC [ <cursor row> ; <cursor column> R@
+reportCursorPosition :: IO ()
+
+saveCursor = hSaveCursor stdout
+restoreCursor = hRestoreCursor stdout
+reportCursorPosition = hReportCursorPosition stdout
+
 hHideCursor, hShowCursor :: Handle
                          -> IO ()
 hideCursor, showCursor :: IO ()

--- a/includes/Exports-Include.hs
+++ b/includes/Exports-Include.hs
@@ -27,6 +27,19 @@ setCursorPosition,
 hSetCursorPosition,
 setCursorPositionCode,
 
+-- * Saving, restoring and reporting cursor position
+saveCursor,
+hSaveCursor,
+saveCursorCode,
+
+restoreCursor,
+hRestoreCursor,
+restoreCursorCode,
+
+reportCursorPosition,
+hReportCursorPosition,
+reportCursorPositionCode,
+
 -- * Clearing parts of the screen
 -- | Note that these functions only clear parts of the screen. They do not move the
 -- cursor.


### PR DESCRIPTION
In response to Issue #7, adds save cursor position, restore cursor position and report cursor position codes - including emulation for versions of Windows that are not ANSI-enabled.

The Windows emulation of save/restore cursor position uses the `unsafePerformIO $ newIORef` 'hack' to emulate a 'global variable' holding the saved cursor position. Saved cursor positions for different handles are held in a `Data.Map.Strict.Map`. 

The Windows emulation of report cursor position uses the Windows function `WriteConsoleInput` to inject characters into the standard input stream. The latter is provided by the Hackage package `Win32-console`.

Two examples are added to `Example.hs`, one for save/restore cursor position and one for report cursor position.
