### PR TITLE
Add 24-bit RGB functionality

### DIFF
--- a/System/Console/ANSI/Types.hs
+++ b/System/Console/ANSI/Types.hs
@@ -10,6 +10,7 @@ module System.Console.ANSI.Types
     , BlinkSpeed (..)
     ) where
 
+import Data.Colour (Colour)
 import Data.Ix
 
 -- | ANSI colors: come in various intensities, which are controlled by 'ColorIntensity'
@@ -60,4 +61,5 @@ data SGR = Reset
          | SetVisible Bool -- ^ Not widely supported
          | SetSwapForegroundBackground Bool
          | SetColor ConsoleLayer ColorIntensity Color
-         deriving (Eq, Ord, Show, Read)
+         | SetRGBColor ConsoleLayer (Colour Float) -- ^ Supported from Windows 10 Creators Update
+         deriving (Eq, Show, Read)

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -29,10 +29,11 @@ Library
         Exposed-Modules:        System.Console.ANSI
                                 System.Console.ANSI.Types
                                 System.Console.ANSI.Codes
-        
+
         Include-Dirs:           includes
-        
+
         Build-Depends:          base >= 4 && < 5
+                              , colour
         if os(windows)
                 Build-Depends:          base-compat >= 0.9.1
                                       , Win32 >= 2.0
@@ -49,15 +50,15 @@ Library
                 -- We assume any non-Windows platform is Unix
                 Cpp-Options:            -DUNIX
                 Other-Modules:          System.Console.ANSI.Unix
-        
+
         Extensions:             CPP
                                 ForeignFunctionInterface
-        
+
         Ghc-Options:                    -Wall
 
 Executable ansi-terminal-example
         Main-Is:                System/Console/ANSI/Example.hs
-        
+
         Include-Dirs:           includes
 
         Other-Modules:          System.Console.ANSI


### PR DESCRIPTION
From version 'Creators Update', Windows 10 supports 24-bit RGB colour. I propose that the `SGR` type is extended to include a  `SetRGBColor ConsoleLayer (Colour Float)` constructor, making use of the `Colour a` type from the `colour` package. As `Colour a` does not have a instance of `Ord`, `SGR` no longer derives `Ord`.

This change requires the type of `sgrToCode` to be updated from `SGR -> Int` to `SGR -> [Int]`, because the SGR parameters are more than a single parameter.

For earlier Windows versions, I have added an emulator that maps to the nearest standard colour (based on the traditional default 16 colours for the Windows console).

