### PR TITLE
Improve Reset emulation

### DIFF
--- a/System/Console/ANSI/Unix.hs
+++ b/System/Console/ANSI/Unix.hs
@@ -8,6 +8,7 @@ import System.Console.ANSI.Types
 import System.IO (Handle, hIsTerminalDevice, hPutStr, stdout)
 
 #include "Common-Include.hs"
+#include "Common-Include-Enabled.hs"
 
 hCursorUp h n = hPutStr h $ cursorUpCode n
 hCursorDown h n = hPutStr h $ cursorDownCode n

--- a/System/Console/ANSI/Windows.hs
+++ b/System/Console/ANSI/Windows.hs
@@ -5,132 +5,114 @@ module System.Console.ANSI.Windows (
 
 import System.Console.ANSI.Types
 import qualified System.Console.ANSI.Unix as U
-import System.Console.ANSI.Windows.Detect (isANSIEnabled)
+import System.Console.ANSI.Windows.Detect (ANSIEnabledStatus (..),
+    ConsoleDefaultState (..), isANSIEnabled)
 import qualified System.Console.ANSI.Windows.Emulator as E
 import System.IO (Handle, hIsTerminalDevice, stdout)
 
 #include "Common-Include.hs"
+#include "Common-Include-Enabled.hs"
+
+-- | A helper function which returns the native or emulated version, depending
+-- on `isANSIEnabled`.
+nativeOrEmulated :: a -> a -> a
+nativeOrEmulated native emulated = case isANSIEnabled of
+    ANSIEnabled      -> native
+    NotANSIEnabled _ -> emulated
+
+-- | A helper function which returns the native or emulated version, depending
+-- on `isANSIEnabled`, where the emulator uses the default console state.
+nativeOrEmulatedWithDefault :: a -> (ConsoleDefaultState -> a) -> a
+nativeOrEmulatedWithDefault native emulated = case isANSIEnabled of
+    ANSIEnabled        -> native
+    NotANSIEnabled def -> emulated def
+
 
 -- * Cursor movement by character
-hCursorUp = if isANSIEnabled then U.hCursorUp else E.hCursorUp
-
-hCursorDown = if isANSIEnabled then U.hCursorDown else E.hCursorDown
-
-hCursorForward = if isANSIEnabled then U.hCursorForward else E.hCursorForward
-
-hCursorBackward = if isANSIEnabled then U.hCursorBackward else E.hCursorBackward
+hCursorUp       = nativeOrEmulated U.hCursorUp       E.hCursorUp
+hCursorDown     = nativeOrEmulated U.hCursorDown     E.hCursorDown
+hCursorForward  = nativeOrEmulated U.hCursorForward  E.hCursorForward
+hCursorBackward = nativeOrEmulated U.hCursorBackward E.hCursorBackward
 
 cursorUpCode :: Int -> String
-cursorUpCode = if isANSIEnabled then U.cursorUpCode else E.cursorUpCode
+cursorUpCode = nativeOrEmulated U.cursorUpCode E.cursorUpCode
 
 cursorDownCode :: Int -> String
-cursorDownCode = if isANSIEnabled then U.cursorDownCode else E.cursorDownCode
+cursorDownCode = nativeOrEmulated U.cursorDownCode E.cursorDownCode
 
 cursorForwardCode :: Int -> String
-cursorForwardCode = if isANSIEnabled
-                    then U.cursorForwardCode
-                    else E.cursorForwardCode
+cursorForwardCode = nativeOrEmulated U.cursorForwardCode E.cursorForwardCode
 
 cursorBackwardCode :: Int -> String
-cursorBackwardCode = if isANSIEnabled
-                     then U.cursorBackwardCode
-                     else E.cursorBackwardCode
+cursorBackwardCode = nativeOrEmulated U.cursorBackwardCode E.cursorBackwardCode
 
 -- * Cursor movement by line
-hCursorUpLine = if isANSIEnabled then U.hCursorUpLine else E.hCursorUpLine
-
-hCursorDownLine = if isANSIEnabled then U.hCursorDownLine else E.hCursorDownLine
+hCursorUpLine   = nativeOrEmulated U.hCursorUpLine   E.hCursorUpLine
+hCursorDownLine = nativeOrEmulated U.hCursorDownLine E.hCursorDownLine
 
 cursorUpLineCode :: Int -> String
-cursorUpLineCode = if isANSIEnabled
-                   then U.cursorUpLineCode
-                   else E.cursorUpLineCode
+cursorUpLineCode = nativeOrEmulated U.cursorUpLineCode E.cursorUpLineCode
 
 cursorDownLineCode :: Int -> String
-cursorDownLineCode = if isANSIEnabled
-                     then U.cursorDownLineCode
-                     else E.cursorDownLineCode
+cursorDownLineCode = nativeOrEmulated U.cursorDownLineCode E.cursorDownLineCode
 
 -- * Directly changing cursor position
-hSetCursorColumn = if isANSIEnabled
-                   then U.hSetCursorColumn
-                   else E.hSetCursorColumn
+hSetCursorColumn = nativeOrEmulated U.hSetCursorColumn E.hSetCursorColumn
 
 setCursorColumnCode :: Int -> String
-setCursorColumnCode = if isANSIEnabled
-                      then U.setCursorColumnCode
-                      else E.setCursorColumnCode
+setCursorColumnCode = nativeOrEmulated
+    U.setCursorColumnCode E.setCursorColumnCode
 
-hSetCursorPosition = if isANSIEnabled
-                     then U.hSetCursorPosition
-                     else E.hSetCursorPosition
+hSetCursorPosition = nativeOrEmulated U.hSetCursorPosition E.hSetCursorPosition
 
 setCursorPositionCode :: Int -> Int -> String
-setCursorPositionCode = if isANSIEnabled
-                        then U.setCursorPositionCode
-                        else E.setCursorPositionCode
+setCursorPositionCode = nativeOrEmulated
+    U.setCursorPositionCode E.setCursorPositionCode
 
 -- * Clearing parts of the screen
-hClearFromCursorToScreenEnd = if isANSIEnabled
-                              then U.hClearFromCursorToScreenEnd
-                              else E.hClearFromCursorToScreenEnd
-
-hClearFromCursorToScreenBeginning = if isANSIEnabled
-                                    then U.hClearFromCursorToScreenBeginning
-                                    else E.hClearFromCursorToScreenBeginning
-
-hClearScreen = if isANSIEnabled then U.hClearScreen else E.hClearScreen
+hClearFromCursorToScreenEnd = nativeOrEmulatedWithDefault
+    U.hClearFromCursorToScreenEnd E.hClearFromCursorToScreenEnd
+hClearFromCursorToScreenBeginning = nativeOrEmulatedWithDefault
+    U.hClearFromCursorToScreenBeginning E.hClearFromCursorToScreenBeginning
+hClearScreen = nativeOrEmulatedWithDefault U.hClearScreen E.hClearScreen
 
 clearFromCursorToScreenEndCode :: String
-clearFromCursorToScreenEndCode = if isANSIEnabled
-                                 then U.clearFromCursorToScreenEndCode
-                                 else E.clearFromCursorToScreenEndCode
+clearFromCursorToScreenEndCode = nativeOrEmulated
+    U.clearFromCursorToScreenEndCode E.clearFromCursorToScreenEndCode
 
 clearFromCursorToScreenBeginningCode :: String
-clearFromCursorToScreenBeginningCode =
-    if isANSIEnabled
-    then U.clearFromCursorToScreenBeginningCode
-    else E.clearFromCursorToScreenBeginningCode
+clearFromCursorToScreenBeginningCode = nativeOrEmulated
+    U.clearFromCursorToScreenBeginningCode E.clearFromCursorToScreenBeginningCode
 
 clearScreenCode :: String
-clearScreenCode = if isANSIEnabled then U.clearScreenCode else E.clearScreenCode
+clearScreenCode = nativeOrEmulated U.clearScreenCode E.clearScreenCode
 
-hClearFromCursorToLineEnd = if isANSIEnabled
-                            then U.hClearFromCursorToLineEnd
-                            else E.hClearFromCursorToLineEnd
-
-hClearFromCursorToLineBeginning = if isANSIEnabled
-                                  then U.hClearFromCursorToLineBeginning
-                                  else E.hClearFromCursorToLineBeginning
-
-hClearLine = if isANSIEnabled then U.hClearLine else E.hClearLine
+hClearFromCursorToLineEnd = nativeOrEmulatedWithDefault
+    U.hClearFromCursorToLineEnd E.hClearFromCursorToLineEnd
+hClearFromCursorToLineBeginning = nativeOrEmulatedWithDefault
+    U.hClearFromCursorToLineBeginning E.hClearFromCursorToLineBeginning
+hClearLine = nativeOrEmulatedWithDefault U.hClearLine E.hClearLine
 
 clearFromCursorToLineEndCode :: String
-clearFromCursorToLineEndCode = if isANSIEnabled
-                               then U.clearFromCursorToLineEndCode
-                               else E.clearFromCursorToLineEndCode
+clearFromCursorToLineEndCode = nativeOrEmulated
+    U.clearFromCursorToLineEndCode E.clearFromCursorToLineEndCode
 
 clearFromCursorToLineBeginningCode :: String
-clearFromCursorToLineBeginningCode = if isANSIEnabled
-                                     then U.clearFromCursorToLineBeginningCode
-                                     else E.clearFromCursorToLineBeginningCode
+clearFromCursorToLineBeginningCode = nativeOrEmulated
+    U.clearFromCursorToLineBeginningCode E.clearFromCursorToLineBeginningCode
 
 clearLineCode :: String
-clearLineCode = if isANSIEnabled then U.clearLineCode else E.clearLineCode
+clearLineCode = nativeOrEmulated U.clearLineCode E.clearLineCode
 
 -- * Scrolling the screen
-hScrollPageUp = if isANSIEnabled then U.hScrollPageUp else E.hScrollPageUp
-hScrollPageDown = if isANSIEnabled then U.hScrollPageDown else E.hScrollPageDown
+hScrollPageUp   = nativeOrEmulatedWithDefault U.hScrollPageUp   E.hScrollPageUp
+hScrollPageDown = nativeOrEmulatedWithDefault U.hScrollPageDown E.hScrollPageDown
 
 scrollPageUpCode :: Int -> String
-scrollPageUpCode = if isANSIEnabled
-                   then U.scrollPageUpCode
-                   else E.scrollPageUpCode
+scrollPageUpCode = nativeOrEmulated U.scrollPageUpCode E.scrollPageUpCode
 
 scrollPageDownCode :: Int -> String
-scrollPageDownCode = if isANSIEnabled
-                     then U.scrollPageDownCode
-                     else E.scrollPageDownCode
+scrollPageDownCode = nativeOrEmulated U.scrollPageDownCode E.scrollPageDownCode
 
 -- * Select Graphic Rendition mode: colors and other whizzy stuff
 --
@@ -145,24 +127,23 @@ scrollPageDownCode = if isANSIEnabled
 -- 25  SetBlinkSpeed NoBlink
 -- 28  SetVisible True
 
-hSetSGR = if isANSIEnabled then U.hSetSGR else E.hSetSGR
+hSetSGR = nativeOrEmulatedWithDefault U.hSetSGR E.hSetSGR
 
 setSGRCode :: [SGR] -> String
-setSGRCode = if isANSIEnabled then U.setSGRCode else E.setSGRCode
+setSGRCode = nativeOrEmulated U.setSGRCode E.setSGRCode
 
 -- * Cursor visibilty changes
-hHideCursor = if isANSIEnabled then U.hHideCursor else E.hHideCursor
-
-hShowCursor = if isANSIEnabled then U.hShowCursor else E.hShowCursor
+hHideCursor = nativeOrEmulated U.hHideCursor E.hHideCursor
+hShowCursor = nativeOrEmulated U.hShowCursor E.hShowCursor
 
 hideCursorCode :: String
-hideCursorCode = if isANSIEnabled then U.hideCursorCode else E.hideCursorCode
+hideCursorCode = nativeOrEmulated U.hideCursorCode E.hideCursorCode
 
 showCursorCode :: String
-showCursorCode = if isANSIEnabled then U.showCursorCode else E.showCursorCode
+showCursorCode = nativeOrEmulated U.showCursorCode E.showCursorCode
 
 -- * Changing the title
-hSetTitle = if isANSIEnabled then U.hSetTitle else E.hSetTitle
+hSetTitle = nativeOrEmulated U.hSetTitle E.hSetTitle
 
 setTitleCode :: String -> String
-setTitleCode = if isANSIEnabled then U.setTitleCode else E.setTitleCode
+setTitleCode = nativeOrEmulated U.setTitleCode E.setTitleCode

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -13,6 +13,8 @@ Homepage:            https://github.com/feuerbach/ansi-terminal
 Build-Type:          Simple
 
 Extra-Source-Files:     includes/Common-Include.hs
+                        includes/Common-Include-Emulator.hs
+                        includes/Common-Include-Enabled.hs
                         includes/Exports-Include.hs
                         CHANGELOG.md
                         README.md

--- a/includes/Common-Include-Emulator.hs
+++ b/includes/Common-Include-Emulator.hs
@@ -1,0 +1,65 @@
+-- This file contains code that is required in the case of the module
+-- System.Console.ANSI.Windows.Emulator and differs from the common code in
+-- file Common-Include-Enabled.hs.
+
+-- | Set the Select Graphic Rendition mode
+hSetSGR
+    :: ConsoleDefaultState -- ^ The default console state
+    -> Handle
+    -> [SGR] -- ^ Commands: these will typically be applied on top of the
+             -- current console SGR mode. An empty list of commands is
+             -- equivalent to the list @[Reset]@. Commands are applied left to
+             -- right.
+    -> IO ()
+
+-- | Set the Select Graphic Rendition mode
+setSGR
+    :: ConsoleDefaultState -- ^ The default console state
+    -> [SGR] -- ^ Commands: these will typically be applied on top of the
+             -- current console SGR mode. An empty list of commands is
+             -- equivalent to the list @[Reset]@. Commands are applied left to
+             -- right.
+    -> IO ()
+setSGR def = hSetSGR def stdout
+
+hClearFromCursorToScreenEnd, hClearFromCursorToScreenBeginning, hClearScreen
+    :: ConsoleDefaultState -- ^ The default console state
+    -> Handle
+    -> IO ()
+
+clearFromCursorToScreenEnd, clearFromCursorToScreenBeginning, clearScreen
+    :: ConsoleDefaultState -- ^ The default console state
+    -> IO ()
+clearFromCursorToScreenEnd def = hClearFromCursorToScreenEnd def stdout
+clearFromCursorToScreenBeginning def
+    = hClearFromCursorToScreenBeginning def stdout
+clearScreen def = hClearScreen def stdout
+
+hClearFromCursorToLineEnd, hClearFromCursorToLineBeginning, hClearLine
+    :: ConsoleDefaultState -- ^ The default console state
+    -> Handle
+    -> IO ()
+
+clearFromCursorToLineEnd, clearFromCursorToLineBeginning, clearLine
+    :: ConsoleDefaultState -- ^ The default console state
+    -> IO ()
+clearFromCursorToLineEnd def = hClearFromCursorToLineEnd def stdout
+clearFromCursorToLineBeginning def = hClearFromCursorToLineBeginning def stdout
+clearLine def = hClearLine def stdout
+
+-- | Scroll the displayed information up or down the terminal: not widely
+-- supported
+hScrollPageUp, hScrollPageDown
+    :: ConsoleDefaultState -- ^ The default console state
+    -> Handle
+    -> Int -- ^ Number of lines to scroll by
+    -> IO ()
+
+-- | Scroll the displayed information up or down the terminal: not widely
+-- supported
+scrollPageUp, scrollPageDown
+    :: ConsoleDefaultState -- ^ The default console state
+    -> Int -- ^ Number of lines to scroll by
+    -> IO ()
+scrollPageUp def = hScrollPageUp def stdout
+scrollPageDown def = hScrollPageDown def stdout

--- a/includes/Common-Include-Enabled.hs
+++ b/includes/Common-Include-Enabled.hs
@@ -1,0 +1,56 @@
+-- This file contains code that is common save that different code is required
+-- in the case of the module System.Console.ANSI.Windows.Emulator (see the file
+-- Common-Include-Emulator.hs in respect of the latter).
+
+-- | Set the Select Graphic Rendition mode
+hSetSGR
+    :: Handle
+    -> [SGR] -- ^ Commands: these will typically be applied on top of the
+             -- current console SGR mode. An empty list of commands is
+             -- equivalent to the list @[Reset]@. Commands are applied left to
+             -- right.
+    -> IO ()
+
+-- | Set the Select Graphic Rendition mode
+setSGR
+    :: [SGR] -- ^ Commands: these will typically be applied on top of the
+             -- current console SGR mode. An empty list of commands is
+             -- equivalent to the list @[Reset]@. Commands are applied left to
+             -- right.
+    -> IO ()
+setSGR = hSetSGR stdout
+
+hClearFromCursorToScreenEnd, hClearFromCursorToScreenBeginning, hClearScreen
+    :: Handle
+    -> IO ()
+
+clearFromCursorToScreenEnd, clearFromCursorToScreenBeginning, clearScreen
+    :: IO ()
+clearFromCursorToScreenEnd = hClearFromCursorToScreenEnd stdout
+clearFromCursorToScreenBeginning = hClearFromCursorToScreenBeginning stdout
+clearScreen = hClearScreen stdout
+
+hClearFromCursorToLineEnd, hClearFromCursorToLineBeginning, hClearLine
+    :: Handle
+    -> IO ()
+
+clearFromCursorToLineEnd, clearFromCursorToLineBeginning, clearLine
+    :: IO ()
+clearFromCursorToLineEnd = hClearFromCursorToLineEnd stdout
+clearFromCursorToLineBeginning = hClearFromCursorToLineBeginning stdout
+clearLine = hClearLine stdout
+
+-- | Scroll the displayed information up or down the terminal: not widely
+-- supported
+hScrollPageUp, hScrollPageDown
+    :: Handle
+    -> Int -- ^ Number of lines to scroll by
+    -> IO ()
+
+-- | Scroll the displayed information up or down the terminal: not widely
+-- supported
+scrollPageUp, scrollPageDown
+    :: Int -- ^ Number of lines to scroll by
+    -> IO ()
+scrollPageUp = hScrollPageUp stdout
+scrollPageDown = hScrollPageDown stdout

--- a/includes/Common-Include.hs
+++ b/includes/Common-Include.hs
@@ -37,46 +37,6 @@ setCursorPosition :: Int -- ^ 0-based row to move to
                   -> IO ()
 setCursorPosition = hSetCursorPosition stdout
 
-hClearFromCursorToScreenEnd, hClearFromCursorToScreenBeginning, hClearScreen :: Handle
-                                                                             -> IO ()
-clearFromCursorToScreenEnd, clearFromCursorToScreenBeginning, clearScreen :: IO ()
-clearFromCursorToScreenEnd = hClearFromCursorToScreenEnd stdout
-clearFromCursorToScreenBeginning = hClearFromCursorToScreenBeginning stdout
-clearScreen = hClearScreen stdout
-
-hClearFromCursorToLineEnd, hClearFromCursorToLineBeginning, hClearLine :: Handle
-                                                                       -> IO ()
-clearFromCursorToLineEnd, clearFromCursorToLineBeginning, clearLine :: IO ()
-
-clearFromCursorToLineEnd = hClearFromCursorToLineEnd stdout
-clearFromCursorToLineBeginning = hClearFromCursorToLineBeginning stdout
-clearLine = hClearLine stdout
-
--- | Scroll the displayed information up or down the terminal: not widely supported
-hScrollPageUp, hScrollPageDown :: Handle
-                               -> Int -- ^ Number of lines to scroll by
-                               -> IO ()
--- | Scroll the displayed information up or down the terminal: not widely supported
-scrollPageUp, scrollPageDown :: Int -- ^ Number of lines to scroll by
-                             -> IO ()
--- | Scroll the displayed information up or down the terminal: not widely supported
-scrollPageUp = hScrollPageUp stdout
-scrollPageDown = hScrollPageDown stdout
-
--- | Set the Select Graphic Rendition mode
-hSetSGR :: Handle
-        -> [SGR] -- ^ Commands: these will typically be applied on top of the current console SGR mode.
-                 -- An empty list of commands is equivalent to the list @[Reset]@. Commands are applied
-                 -- left to right.
-        -> IO ()
--- | Set the Select Graphic Rendition mode
-setSGR :: [SGR] -- ^ Commands: these will typically be applied on top of the current console SGR mode.
-                -- An empty list of commands is equivalent to the list @[Reset]@. Commands are applied
-                -- left to right.
-       -> IO ()
--- | Set the Select Graphic Rendition mode
-setSGR = hSetSGR stdout
-
 hHideCursor, hShowCursor :: Handle
                          -> IO ()
 hideCursor, showCursor :: IO ()


### PR DESCRIPTION
Currently, the emulation (for versions of Windows without an ANSI-aware console) fills blank space with 'colour 0' (usually black) and 'resets' to 'colour  7 on colour 0' (usually silver on black). This may upset PowerShell users (or others) who have a different default - for example, `Reset` does not return them to where they started.

This proposal changes the emulation so that the default colours are those of the console when the emulation starts.

The default colours are captured in module `System.Console.ANSI.Windows.Detect` and preserved: `isANSIEnabled` is now a value of type `ANSIEnabledState` (rather than `Bool`) which has a constructor `NotANSIEnabled ConsoleDefaultState`. The emulated version of the affected functions (eg `hClearScreen` and `hSetSGR`) are then a function of the 'console default state' (as well as the other arguments).

This sees: (1) some of the original `Common-Include.hs` split out into `Common-Include-Enabled.hs` or, as applicable, `Common-Include-Emulator.hs`; and (2) `if then else` choices in module  `System.Console.ANSI.Windows` become `case of` choices.

