### PR TITLE
Parse reportCursorPosition output

### DIFF
--- a/includes/Exports-Include.hs
+++ b/includes/Exports-Include.hs
@@ -1,3 +1,7 @@
+-- This file contains code that is common to modules
+-- System.Console.ANSI.Unix and System.Console.ANSI.Windows, namely the module
+-- exports and the associated Haddock documentation.
+
 -- * Basic data types
 module System.Console.ANSI.Types,
 
@@ -71,5 +75,6 @@ setTitle,
 hSetTitle,
 setTitleCode,
 
--- * Checking if handle supports ANSI
-hSupportsANSI
+-- * Utilities
+hSupportsANSI,
+cursorPosition


### PR DESCRIPTION
This makes use of the `parsec` package to create parser `cursorPosition` (I followed the pattern of the `parsec` package of naming the parser after the thing that it returns). Documentation has been included.

Documentation has been added to `reportCursorPosition`. As indicated, on Windows at least, obtaining data from the console input stream is non-trivial. I have some ideas in that regard, but I intend to make them a separate pull request to the parser because they are complex.

Some general documentation has also been added to the files that have been edited. In the case of Common-Include.hs, a few lines longer than 80 characters have also been reformatted to be shorter.