### PR TITLE
Add getReportedCursorPosition & getCursorPosition

### DIFF
--- a/System/Console/ANSI/Example.hs
+++ b/System/Console/ANSI/Example.hs
@@ -20,7 +20,7 @@ examples = [ cursorMovementExample
            , sgrExample
            , cursorVisibilityExample
            , titleExample
-           , reportCursorPositionExample
+           , getCursorPositionExample
            ]
 
 main :: IO ()
@@ -295,9 +295,24 @@ titleExample = do
     ---------------------------------------------------
     -- Title Demo
 
-reportCursorPositionExample :: IO ()
-reportCursorPositionExample = do
-    putStr "Report cursor position here:"
+getCursorPositionExample :: IO ()
+getCursorPositionExample = do
+    putStrLn "         11111111112222222222"
+    putStrLn "12345678901234567890123456789"
+    putStr   "Report cursor position here:"
     pause
-    reportCursorPosition
-    putStrLn " (1st row, 29th column) to stdin, as CSI 1 ; 29 R."
+    --          11111111112222222222
+    -- 12345678901234567890123456789
+    -- Report cursor position here:|
+    result <- getCursorPosition
+    putStrLn " (3rd row, 29th column) to stdin, as CSI 3 ; 29 R.\n"
+    case result of
+        Just (row, col) -> putStrLn $ "The cursor was at row number " ++
+            show row ++ " and column number " ++ show col ++ ".\n"
+        Nothing -> putStrLn "Error: unable to get the cursor position\n"
+    pause
+    --          11111111112222222222
+    -- 12345678901234567890123456789
+    -- Report cursor position here: (3rd row, 29th column) to stdin, as CSI 3 ; 29 R.
+    --
+    -- The cursor was at row number 3 and column number 29.

--- a/System/Console/ANSI/Unix.hs
+++ b/System/Console/ANSI/Unix.hs
@@ -1,13 +1,28 @@
 {-# OPTIONS_HADDOCK hide #-}
+
 module System.Console.ANSI.Unix (
+-- This file contains code that is common to modules
+-- System.Console.ANSI.Unix and System.Console.ANSI.Windows, namely the module
+-- exports and the associated Haddock documentation.
 #include "Exports-Include.hs"
     ) where
 
+import Control.Exception.Base (bracket)
 import System.Console.ANSI.Codes
 import System.Console.ANSI.Types
-import System.IO (Handle, hIsTerminalDevice, hPutStr, stdout)
+import System.IO (BufferMode (..), Handle, hFlush, hGetBuffering, hGetEcho,
+    hIsTerminalDevice, hPutStr, hSetBuffering, hSetEcho, stdin, stdout)
+import Text.ParserCombinators.ReadP (readP_to_S)
 
+-- This file contains code that is common to modules System.Console.ANSI.Unix,
+-- System.Console.ANSI.Windows and System.Console.ANSI.Windows.Emulator, such as
+-- type signatures and the definition of functions specific to stdout in terms
+-- of the corresponding more general functions, inclduding the related Haddock
+-- documentation.
 #include "Common-Include.hs"
+-- This file contains code that is common save that different code is required
+-- in the case of the module System.Console.ANSI.Windows.Emulator (see the file
+-- Common-Include-Emulator.hs in respect of the latter).
 #include "Common-Include-Enabled.hs"
 
 hCursorUp h n = hPutStr h $ cursorUpCode n
@@ -42,3 +57,40 @@ hHideCursor h = hPutStr h hideCursorCode
 hShowCursor h = hPutStr h showCursorCode
 
 hSetTitle h title = hPutStr h $ setTitleCode title
+
+-- getReportedCursorPosition :: IO String
+-- (See Common-Include.hs for Haddock documentation)
+getReportedCursorPosition = bracket (hGetEcho stdin) (hSetEcho stdin) $ const get
+  where
+    get = do
+        c <- getChar
+        if c == '\ESC'
+            then get' [c]
+            else return [c] -- If the first character is not the expected
+                            -- \ESC then give up. This provides a modicom of
+                            -- protection against unexpected data in the
+                            -- input stream.
+    get' s = do
+        c <- getChar
+        if c /= 'R'
+            then get' (c:s) -- Continue building the list, until the expected 'R'
+                            -- character is obtained. Build the list in reverse
+                            -- order, in order to avoid O(n^2) complexity.
+            else return $ reverse (c:s) -- Reverse the order of the built list.
+
+-- getCursorPosition :: IO (Maybe (Int, Int))
+-- (See Common-Include.hs for Haddock documentation)
+getCursorPosition = do
+    input <- bracket (hGetBuffering stdin) (hSetBuffering stdin) $ \_ -> do
+        hSetBuffering stdin NoBuffering -- set no buffering (the contents of the
+                                        -- buffer will be discarded, so this
+                                        -- needs to be done before the cursor
+                                        -- positon is emitted)
+        reportCursorPosition
+        hFlush stdout -- ensure the report cursor position code is sent to the
+                      -- operating system
+        getReportedCursorPosition
+    case readP_to_S cursorPosition input of
+        [] -> return Nothing
+        [((row, col),_)] -> return $ Just (row, col)
+        (_:_) -> return Nothing

--- a/System/Console/ANSI/Windows.hs
+++ b/System/Console/ANSI/Windows.hs
@@ -1,5 +1,9 @@
 {-# OPTIONS_HADDOCK hide #-}
+
 module System.Console.ANSI.Windows (
+-- This file contains code that is common to modules
+-- System.Console.ANSI.Unix and System.Console.ANSI.Windows, namely the module
+-- exports and the associated Haddock documentation.
 #include "Exports-Include.hs"
     ) where
 
@@ -10,7 +14,15 @@ import System.Console.ANSI.Windows.Detect (ANSIEnabledStatus (..),
 import qualified System.Console.ANSI.Windows.Emulator as E
 import System.IO (Handle, hIsTerminalDevice, stdout)
 
+-- This file contains code that is common to modules System.Console.ANSI.Unix,
+-- System.Console.ANSI.Windows and System.Console.ANSI.Windows.Emulator, such as
+-- type signatures and the definition of functions specific to stdout in terms
+-- of the corresponding more general functions, inclduding the related Haddock
+-- documentation.
 #include "Common-Include.hs"
+-- This file contains code that is common save that different code is required
+-- in the case of the module System.Console.ANSI.Windows.Emulator (see the file
+-- Common-Include-Emulator.hs in respect of the latter).
 #include "Common-Include-Enabled.hs"
 
 -- | A helper function which returns the native or emulated version, depending
@@ -163,3 +175,11 @@ hSetTitle = nativeOrEmulated U.hSetTitle E.hSetTitle
 
 setTitleCode :: String -> String
 setTitleCode = nativeOrEmulated U.setTitleCode E.setTitleCode
+
+-- getReportedCursorPosition :: IO String
+-- (See Common-Include.hs for Haddock documentation)
+getReportedCursorPosition = E.getReportedCursorPosition
+
+-- getCursorPosition :: IO (Maybe (Int, Int))
+-- (See Common-Include.hs for Haddock documentation)
+getCursorPosition = E.getCursorPosition

--- a/includes/Exports-Include.hs
+++ b/includes/Exports-Include.hs
@@ -1,3 +1,7 @@
+-- This file contains code that is common to modules
+-- System.Console.ANSI.Unix and System.Console.ANSI.Windows, namely the module
+-- exports and the associated Haddock documentation.
+
 -- * Basic data types
 module System.Console.ANSI.Types,
 
@@ -71,5 +75,6 @@ setTitle,
 hSetTitle,
 setTitleCode,
 
--- * Checking if handle supports ANSI
-hSupportsANSI
+-- * Utilities
+hSupportsANSI,
+cursorPosition

--- a/includes/Exports-Include.hs
+++ b/includes/Exports-Include.hs
@@ -75,6 +75,10 @@ setTitle,
 hSetTitle,
 setTitleCode,
 
--- * Utilities
+-- * Checking if handle supports ANSI
 hSupportsANSI,
+
+-- * Getting the cursor position
+getCursorPosition,
+getReportedCursorPosition,
 cursorPosition


### PR DESCRIPTION
This builds on open pull request #30 (parse reportCursorPosition output).

I've tested it on Microsoft's consoles (Command Prompt and PowerShell) on Windows and on Terminal on Mac OS X. However, it does not work on non-Microsoft consoles on Windows (specifically, mintty 2.7.7). That may reflect a more general issue. The world of consoles and ANSI and GHC has got more complicated:

-  Microsoft's ANSI-incapable consoles on Windows
- Microsoft's ANSI-capable consoles on modern Windows (or the Windows Subsystem for Linux on Windows)
- non-Microsoft ANSI-capable consoles on Windows
- ANSI-capable consoles on Unix-like operating systems
- GHC's basic System.IO behaves differently on Unix and Windows

It may not be enough for `ansi-terminal` to 'know' if it is on Windows or on a Unix-like operating system and (if it is on Windows) to know if the console is ANSI-capable or ANSI-incapable. `ansi-terminal` may need to know if an ANSI-capable console on Windows is a Microsoft console or a non-Microsoft console (and perhaps it would be useful for `ansi-terminal` to export what it knows or assumes).

The existing `reportCursorPosition` function (and related functions) emits data into the console input stream.

New `getReportedCursorPosition` helps retrieve that emitted data from the stream.

New `getCursorPosition` combines `reportCursorPosition`, `getReportedCursorPosition` and `cursorPosition` (the parser, #30).

On Unix-like operating systems, `getReportedCursorPosition` uses `getChar` with buffering turned off (so that characters are available before the enter key is pressed).

However, on all Windows operating systems, where no buffering does not work for `getChar` under GHC, a different approach is required. Here, use is made of the low level `readConsoleInput` function from the Windows Console API. Consequently, the remainder of the Windows `INPUT_RECORD` structure is implemented in module `System.Console.ANSI.Windows.Foreign`. However, the use of `readConsoleInput` causes an error if the console on Windows is not a Microsoft console. EDIT: A, hopefully, helpful error message has been added.

The use of `getCursorPosition` is provided as an example (now named `getCursorPositionExample`).