### PR TITLE
Fix recent Haddock documentation

### DIFF
--- a/includes/Common-Include.hs
+++ b/includes/Common-Include.hs
@@ -40,14 +40,14 @@ setCursorPosition = hSetCursorPosition stdout
 hSaveCursor, hRestoreCursor, hReportCursorPosition :: Handle -> IO ()
 
 -- | Save the cursor position in memory. The only way to access the saved value
--- is with the `restoreCursor` command.
+-- is with the 'restoreCursor' command.
 saveCursor :: IO ()
 -- | Restore the cursor position from memory. There will be no value saved in
--- memory until the first use of the `saveCursor` command.
+-- memory until the first use of the 'saveCursor' command.
 restoreCursor :: IO ()
 -- | Emit the cursor position into the console input stream, immediately after
 -- being recognised on the output stream, as:
--- @ESC [ <cursor row> ; <cursor column> R@
+-- @ESC [ \<cursor row> ; \<cursor column> R@
 reportCursorPosition :: IO ()
 
 saveCursor = hSaveCursor stdout


### PR DESCRIPTION
The markup in some recent Haddock documentation was not correct. This fixes that.