### PR TITLE
Improve System.Console.ANSI.Codes documentation

### DIFF
--- a/System/Console/ANSI.hs
+++ b/System/Console/ANSI.hs
@@ -3,10 +3,12 @@
 -- or on other Windows operating systems where the terminal in use is not
 -- ANSI-enabled.
 --
--- The ANSI escape codes are described at <http://en.wikipedia.org/wiki/ANSI_escape_code> and provide a rich range of
--- functionality for terminal control, which includes:
+-- The ANSI escape codes are described at <http://en.wikipedia.org/wiki/ANSI_escape_code>
+-- and provide a rich range of functionality for terminal control, which
+-- includes:
 --
---  * Colored text output, with control over both foreground and background colors
+--  * Colored text output, with control over both foreground and background
+--    colors
 --
 --  * Hiding or showing the cursor
 --
@@ -14,26 +16,30 @@
 --
 --  * Clearing parts of the screen
 --
--- The most frequently used parts of this ANSI command set are exposed with a platform independent interface by
--- this module.  Every function exported comes in three flavours:
+-- The most frequently used parts of this ANSI command set are exposed with a
+-- platform independent interface by this module.  Every function exported comes
+-- in three flavours:
 --
---  * Vanilla: has an @IO ()@ type and doesn't take a @Handle@.  This just outputs the ANSI command directly on
---    to the terminal corresponding to stdout.  Commands issued like this should work as you expect on both Windows
+--  * Vanilla: has an @IO ()@ type and doesn't take a @Handle@.  This just
+--    outputs the ANSI command directly on to the terminal corresponding to
+--    stdout. Commands issued like this should work as you expect on both
+--    Windows and Unix.
+--
+--  * Chocolate: has an @IO ()@ type but takes a @Handle@.  This outputs the
+--    ANSI command on the terminal corresponding to the supplied handle.
+--    Commands issued like this should also work as you expect on both Windows
 --    and Unix.
 --
---  * Chocolate: has an @IO ()@ type but takes a @Handle@.  This outputs the ANSI command on the terminal corresponding
---    to the supplied handle.  Commands issued like this should also work as you expect on both Windows and Unix.
---
---  * Strawberry: has a @String@ type and just consists of an escape code which can be added to any other bit of text
---    before being output. The use of these codes is generally discouraged
---    because they will not work on Windows operating systems where the terminal in use
---    is not ANSI-enabled (such as those before Windows 10 Threshold 2). On
---    versions of Windows where the terminal in use is not ANSI-enabled, these
---    codes will always be the empty string, so it is possible to use them
---    portably for e.g. coloring console output on the understanding that you
---    will only see colors if you are running on an operating system that is
---    Unix-like or is a version of Windows where the terminal in use is ANSI-
---    enabled.
+--  * Strawberry: has a @String@ type and just consists of an escape code which
+--    can be added to any other bit of text before being output. The use of
+--    these codes is generally discouraged because they will not work on Windows
+--    operating systems where the terminal in use is not ANSI-enabled (such as
+--    those before Windows 10 Threshold 2). On versions of Windows where the
+--    terminal in use is not ANSI-enabled, these codes will always be the empty
+--    string, so it is possible to use them portably for e.g. coloring console
+--    output on the understanding that you will only see colors if you are
+--    running on an operating system that is Unix-like or is a version of
+--    Windows where the terminal in use is ANSI-enabled.
 --
 -- Example:
 --

--- a/System/Console/ANSI/Codes.hs
+++ b/System/Console/ANSI/Codes.hs
@@ -1,13 +1,21 @@
--- | Functions that return 'String' values containing codes in accordance with:
--- (1) standard ECMA-48 Control Functions for Coded Character Sets (5th edition,
--- 1991); or (2) in the case of 'setTitleCode', the XTerm control sequence.
+-- | This module exports functions that return 'String' values containing codes
+-- in accordance with: (1) standard ECMA-48 Control Functions for Coded
+-- Character Sets (5th edition, 1991); or (2) in the case of 'saveCursorCode',
+-- 'restoreCursorCode', 'reportCursorPositionCode' and 'setTitleCode', the XTerm
+-- control sequence.
 --
 -- The reference used for the codes in this module was
 -- <http://en.wikipedia.org/wiki/ANSI_escape_sequences>.
 --
--- If module "System.Console.ANSI" is also imported, this module is intended to
--- be imported qualified, to avoid name clashes with functions which return \"\"
--- when Windows ANSI terminal support is emulated. e.g.
+-- The module "System.Console.ANSI" exports functions with the same names as
+-- those in this module. On some versions of Windows, the terminal in use may
+-- not be ANSI-capable. When that is the case, the same-named functions exported
+-- by module "System.Console.ANSI" return \"\", for the reasons set out in the
+-- documentation of that module.
+--
+-- Consequently, if module "System.Console.ANSI" is also imported, this module
+-- is intended to be imported qualified, to avoid name clashes with those
+-- functions. For example:
 --
 -- > import qualified System.Console.ANSI.Codes as ANSI
 --


### PR DESCRIPTION
In response to issue #25, this proposal seeks to clarify the introductory documentation in module `System.Console.ANSI.Codes`.

In so doing, I have also refactored the documentation in `System.Console.ANSI` to respect a line length of 80 but not otherwise changed that documentation (which may partly address issue #17).