### PR TITLE
Fix Data.Typeable in System.Console.ANSI.Windows.Foreign

### DIFF
--- a/System/Console/ANSI/Windows/Foreign.hs
+++ b/System/Console/ANSI/Windows/Foreign.hs
@@ -54,14 +54,11 @@ import Foreign.Storable
 
 import Data.Bits
 import Data.Char
+import Data.Typeable (Typeable, cast)
 
 import System.Win32.Types
 
 import Control.Exception (Exception, throw)
-
-#if __GLASGOW_HASKELL__ >= 612
-import Data.Typeable
-#endif
 
 #if !MIN_VERSION_Win32(2,5,1)
 import Control.Concurrent.MVar
@@ -70,7 +67,6 @@ import Control.Exception (bracket)
 #if __GLASGOW_HASKELL__ >= 612
 import GHC.IO.Handle.Types (Handle(..), Handle__(..))
 import GHC.IO.FD (FD(..)) -- A wrapper around an Int32
-import Data.Typeable
 #else
 import GHC.IOBase (Handle(..), Handle__(..))
 import qualified GHC.IOBase as IOBase (FD) -- Just an Int32


### PR DESCRIPTION
In the current module `System.Console.ANSI.Windows.Foreign`, module `Data.Typeable` is imported only if the GHC version >= 6.12 (`base-4.2.0.0`, Dec 2009) but type `ConsoleException` is an instance of class `Typeable` for **all** versions of GHC. Also, the import of `Data.Typeable` is duplicated if the version of the `Win32` package is >= 2.5.1. It appears the former (the >= 6.12 constraint) dates from when only function `cast` (from `Data.Typeable`) was used, and used only in versions of `withHandleToHANDLE` implemented for GHC versions >= 6.12.

This proposed commit removes the GHC version >= 6.12 constraint for the import of `Data.Typeable`; eliminates the duplicated import; and, consistent with Johan Tibell (`hindent`) style  (see #17), uses explicit imports for `Data.Typeable` (namely `Typeable` and `cast`) and places the import in alphabetical order in relation to other imports.

In respect of the removal of the GHC version >= 6.12 constraint, the `.cabal` file specifies `base >=4` (GHC 6.10.1, Nov 2008) and `Data.Typeable (Typeable, cast)` were available in package `base-4.0.0.0`.

In terms of testing, I have tested that this does not affect building on Windows 10 using GHC 8.0.2.