### PR TITLE
Change to avoid warning about discarded do-notation statement result

### DIFF
--- a/System/Console/ANSI/Windows/Emulator.hs
+++ b/System/Console/ANSI/Windows/Emulator.hs
@@ -144,7 +144,7 @@ hClearScreenFraction cds handle fraction_finder = do
         right' = if y == bottom then end_x   else right
         fill_cursor_pos = COORD left' y
         fill_length = fromIntegral $ right' - left' + 1
-    fillConsoleOutputCharacter handle clearChar fill_length fill_cursor_pos
+    _ <- fillConsoleOutputCharacter handle clearChar fill_length fill_cursor_pos
     fillConsoleOutputAttribute handle (clearAttribute cds) fill_length
       fill_cursor_pos
 


### PR DESCRIPTION
A fix in response to this warning:
~~~~
System\Console\ANSI\Windows\Emulator.hs:147:5: warning: [-Wunused-do-bind]
    A do-notation statement discarded a result of type `DWORD'
    Suppress this warning by saying
      `_ <- fillConsoleOutputCharacter
              handle clearChar fill_length fill_cursor_pos'
~~~~