### PR TITLE
Update stack.yaml to LTS 9.20 (for GHC 8.0.2)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 extra-deps: []
-resolver: lts-8.13
+resolver: lts-9.20
 flags:
   ansi-terminal:
     example: false


### PR DESCRIPTION
LTS 8.13 is also for GHC 8.0.2, but LTS 9.20 includes package colour-2.3.4.