### PR TITLE
Send informative error to stderr not stdout

### DIFF
--- a/System/Console/ANSI/Windows/Detect.hs
+++ b/System/Console/ANSI/Windows/Detect.hs
@@ -43,7 +43,7 @@ isANSIEnabled = unsafePerformIO $ do
   e <- safeIsANSIEnabled
   if e
     then return ANSIEnabled
-    else onException (do
+    else do
       hOut <- getValidStdHandle sTD_OUTPUT_HANDLE
       info <- getConsoleScreenBufferInfo hOut
       let attributes = csbi_attributes info
@@ -52,16 +52,7 @@ isANSIEnabled = unsafePerformIO $ do
           consoleDefaultState = ConsoleDefaultState
             { defaultForegroundAttributes = fgAttributes
             , defaultBackgroundAttributes = bgAttributes }
-      return $ NotANSIEnabled consoleDefaultState)
-      (putStrLn $ "A fatal error has occurred. An attempt has been made to " ++
-        "send console virtual terminal sequences (ANSI codes) to an output " ++
-        "that has not been recognised as an ANSI-capable terminal and also " ++
-        "cannot be emulated as an ANSI-enabled terminal (emulation needs a " ++
-        "ConHost-based terminal, such as Command Prompt or PowerShell).\n\n" ++
-        "If that is unexpected, please post an issue at the home page of " ++
-        "the ansi-terminal package. See " ++
-        "https://hackage.haskell.org/package/ansi-terminal for the home " ++
-        "page location.\n")
+      return $ NotANSIEnabled consoleDefaultState
 
 -- This function takes the following approach. If the environment variable
 -- APPVEYOR exists and is set to 'True', it assumes the code is running in the

--- a/System/Console/ANSI/Windows/Foreign.hs
+++ b/System/Console/ANSI/Windows/Foreign.hs
@@ -339,7 +339,20 @@ foreign import WINDOWS_CCONV unsafe "windows.h ReadConsoleInputW"
                     -> LPDWORD
                     -> IO BOOL
 
-data ConsoleException = ConsoleException !ErrCode deriving (Show, Eq, Typeable)
+data ConsoleException = ConsoleException !ErrCode deriving (Eq, Typeable)
+
+instance Show ConsoleException where
+  show (ConsoleException 6) =
+    "A fatal error has occurred.\n\n" ++
+    "An attempt has been made to send console virtual terminal sequences\n" ++
+    "(ANSI codes) to an output that has not been recognised as an\n" ++
+    "ANSI-capable terminal and also cannot be emulated as an ANSI-enabled\n" ++
+    "terminal (emulation needs a ConHost-based terminal, such as Command\n" ++
+    "Prompt or PowerShell). That may occur, for example, if output has\n" ++
+    "been redirected to a file.\n\n" ++
+    "If that is unexpected, please post an issue at:\n" ++
+    "https://github.com/feuerbach/ansi-terminal/issues\n"
+  show (ConsoleException errCode) = "ConsoleException " ++ show errCode
 
 instance Exception ConsoleException
 


### PR DESCRIPTION
Part-solution to #52. The informative error is now sent to `stderr` so that it will be available when `stdout` has been redirected from the console. This is implemented by means of an instance of `Show` for `ConsoleException`.