### PR TITLE
Support only GHC 6.12.1 (Dec 2009) onward

### DIFF
--- a/System/Console/ANSI/Windows/Foreign.hs
+++ b/System/Console/ANSI/Windows/Foreign.hs
@@ -68,14 +68,9 @@ import Foreign.Storable (Storable (..))
 import Control.Concurrent.MVar (readMVar)
 import Control.Exception (bracket)
 import Foreign.StablePtr (StablePtr, freeStablePtr, newStablePtr)
-#if __GLASGOW_HASKELL__ >= 612
 import Data.Typeable (cast)
 import GHC.IO.FD (FD(..)) -- A wrapper around an Int32
 import GHC.IO.Handle.Types (Handle (..), Handle__ (..))
-#else
-import GHC.IOBase (Handle (..), Handle__ (..))
-import qualified GHC.IOBase as IOBase (FD)  -- Just an Int32
-#endif
 #endif
 
 import System.Win32.Types (BOOL, DWORD, ErrCode, HANDLE, LPCTSTR, LPDWORD,
@@ -452,14 +447,8 @@ withHandleToHANDLE haskell_handle action =
           -- we could also take the "read" one
 
     -- Get the FD from the algebraic data type
-#if __GLASGOW_HASKELL__ < 612
-    fd <- fmap haFD $ readMVar write_handle_mvar
-#else
-    -- readMVar write_handle_mvar >>= \(Handle__ { haDevice = dev }) ->
-    -- print (typeOf dev)
     Just fd <- fmap (\(Handle__ { haDevice = dev }) ->
       fmap fdFD (cast dev)) $ readMVar write_handle_mvar
-#endif
 
     -- Finally, turn that (C-land) FD into a HANDLE using msvcrt
     windows_handle <- cget_osfhandle fd
@@ -470,13 +459,8 @@ withHandleToHANDLE haskell_handle action =
 -- This essential function comes from the C runtime system. It is certainly
 -- provided by msvcrt, and also seems to be provided by the mingw C library -
 -- hurrah!
-#if __GLASGOW_HASKELL__ >= 612
 foreign import WINDOWS_CCONV unsafe "_get_osfhandle"
   cget_osfhandle :: CInt -> IO HANDLE
-#else
-foreign import WINDOWS_CCONV unsafe "_get_osfhandle"
-  cget_osfhandle :: IOBase.FD -> IO HANDLE
-#endif
 
 -- withStablePtr was added in Win32-2.5.1.0
 withStablePtr :: a -> (StablePtr a -> IO b) -> IO b

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -35,7 +35,7 @@ Library
 
         Include-Dirs:           includes
 
-        Build-Depends:          base >= 4 && < 5
+        Build-Depends:          base >= 4.2.0.0 && < 5
                               , colour
         if os(windows)
                 Build-Depends:          base-compat >= 0.9.1
@@ -83,7 +83,7 @@ Executable ansi-terminal-example
                 -- We assume any non-Windows platform is Unix
                 Cpp-Options:            -DUNIX
 
-        Build-Depends:          base >= 4 && < 5
+        Build-Depends:          base >= 4.2.0.0 && < 5
         Extensions:             CPP
                                 ForeignFunctionInterface
 


### PR DESCRIPTION
Removing support for versions of GHC before GHC 6.12.1 (December 2009) reduces the amount of CPP spaghetti in module `System.Console.ANSI.Windows.Foreign`.