### PR TITLE
Refactor into System.Win32.Compat

### DIFF
--- a/System/Console/ANSI/Windows/Foreign.hs
+++ b/System/Console/ANSI/Windows/Foreign.hs
@@ -55,35 +55,14 @@ import Data.Bits ((.|.), shiftL)
 import Data.Char (chr, ord)
 import Data.Typeable (Typeable)
 import Foreign.C.Types (CInt (..), CWchar (..))
--- Some Windows types missing from System.Win32 prior to version 2.5.0.0
-#if !MIN_VERSION_Win32(2,5,0)
-import Foreign.C.Types (CShort (..))
-#endif
 import Foreign.Marshal (alloca, allocaArray, maybeWith, peekArray, with,
   withArrayLen)
 import Foreign.Ptr (Ptr, castPtr, plusPtr)
 import Foreign.Storable (Storable (..))
-
-#if !MIN_VERSION_Win32(2,5,1)
-import Control.Concurrent.MVar (readMVar)
-import Control.Exception (bracket)
-import Foreign.StablePtr (StablePtr, freeStablePtr, newStablePtr)
-import Data.Typeable (cast)
-import GHC.IO.FD (FD(..)) -- A wrapper around an Int32
-import GHC.IO.Handle.Types (Handle (..), Handle__ (..))
-#endif
-
-import System.Win32.Types (BOOL, DWORD, ErrCode, HANDLE, LPCTSTR, LPDWORD,
-  TCHAR, UINT, WORD, failIfFalse_, getLastError, iNVALID_HANDLE_VALUE,
-  nullHANDLE, withTString)
--- Missing from System.Win32.Types prior to version 2.5.0.0
-#if MIN_VERSION_Win32(2,5,0)
-import System.Win32.Types (SHORT)
-#endif
--- withHandleToHANDLE added to System.Win32.Types from version 2.5.1.0
-#if MIN_VERSION_Win32(2,5,1)
-import System.Win32.Types (withHandleToHANDLE)
-#endif
+-- `SHORT` and `withHandleToHANDLE` are not both available before Win32-2.5.1.0
+import System.Win32.Compat (BOOL, DWORD, ErrCode, HANDLE, LPCTSTR, LPDWORD,
+  SHORT, TCHAR, UINT, WORD, failIfFalse_, getLastError, iNVALID_HANDLE_VALUE,
+  nullHANDLE, withHandleToHANDLE, withTString)
 
 #if defined(i386_HOST_ARCH)
 #define WINDOWS_CCONV stdcall
@@ -93,10 +72,6 @@ import System.Win32.Types (withHandleToHANDLE)
 #error Unknown mingw32 arch
 #endif
 
--- Missing from System.Win32.Types prior to version 2.5.0.0
-#if !MIN_VERSION_Win32(2,5,0)
-type SHORT = CShort
-#endif
 type WCHAR = CWchar
 
 charToWCHAR :: Char -> WCHAR
@@ -424,48 +399,6 @@ scrollConsoleScreenBuffer
     with fill $ \ptr_fill ->
     throwIfFalse $ cScrollConsoleScreenBuffer handle ptr_scroll_rectangle
       ptr_clip_rectangle (unpackCOORD destination_origin) ptr_fill
-
--- withHandleToHANDLE added to System.Win32.Types from version 2.5.1.0
-#if !MIN_VERSION_Win32(2,5,1)
--- | This bit is all highly dubious. The problem is that we want to output ANSI
--- to arbitrary Handles rather than forcing people to use stdout.  However, the
--- Windows ANSI emulator needs a Windows HANDLE to work it's magic, so we need
--- to be able to extract one of those from the Haskell Handle.
---
--- This code accomplishes this, albeit at the cost of only being compatible with
--- GHC. withHandleToHANDLE was added in Win32-2.5.1.0
-withHandleToHANDLE :: Handle -> (HANDLE -> IO a) -> IO a
-withHandleToHANDLE haskell_handle action =
-  -- Create a stable pointer to the Handle. This prevents the garbage collector
-  -- getting to it while we are doing horrible manipulations with it, and hence
-  -- stops it being finalized (and closed).
-  withStablePtr haskell_handle $ const $ do
-    -- Grab the write handle variable from the Handle
-    let write_handle_mvar = case haskell_handle of
-          FileHandle _ handle_mvar     -> handle_mvar
-          DuplexHandle _ _ handle_mvar -> handle_mvar -- This is "write" MVar,
-          -- we could also take the "read" one
-
-    -- Get the FD from the algebraic data type
-    Just fd <- fmap (\(Handle__ { haDevice = dev }) ->
-      fmap fdFD (cast dev)) $ readMVar write_handle_mvar
-
-    -- Finally, turn that (C-land) FD into a HANDLE using msvcrt
-    windows_handle <- cget_osfhandle fd
-
-    -- Do what the user originally wanted
-    action windows_handle
-
--- This essential function comes from the C runtime system. It is certainly
--- provided by msvcrt, and also seems to be provided by the mingw C library -
--- hurrah!
-foreign import WINDOWS_CCONV unsafe "_get_osfhandle"
-  cget_osfhandle :: CInt -> IO HANDLE
-
--- withStablePtr was added in Win32-2.5.1.0
-withStablePtr :: a -> (StablePtr a -> IO b) -> IO b
-withStablePtr value = bracket (newStablePtr value) freeStablePtr
-#endif
 
 -- The following is based on module System.Win32.Console.Extra from package
 -- Win32-console, cut down for the WCHAR version of writeConsoleInput.

--- a/System/Console/ANSI/Windows/Foreign.hs
+++ b/System/Console/ANSI/Windows/Foreign.hs
@@ -68,14 +68,9 @@ import Foreign.Storable (Storable (..))
 import Control.Concurrent.MVar (readMVar)
 import Control.Exception (bracket)
 import Foreign.StablePtr (StablePtr, freeStablePtr, newStablePtr)
-#if __GLASGOW_HASKELL__ >= 612
 import Data.Typeable (cast)
 import GHC.IO.FD (FD(..)) -- A wrapper around an Int32
 import GHC.IO.Handle.Types (Handle (..), Handle__ (..))
-#else
-import GHC.IOBase (Handle (..), Handle__ (..))
-import qualified GHC.IOBase as IOBase (FD)  -- Just an Int32
-#endif
 #endif
 
 import System.Win32.Types (BOOL, DWORD, ErrCode, HANDLE, LPCTSTR, LPDWORD,
@@ -452,14 +447,8 @@ withHandleToHANDLE haskell_handle action =
           -- we could also take the "read" one
 
     -- Get the FD from the algebraic data type
-#if __GLASGOW_HASKELL__ < 612
-    fd <- fmap haFD $ readMVar write_handle_mvar
-#else
-    -- readMVar write_handle_mvar >>= \(Handle__ { haDevice = dev }) ->
-    -- print (typeOf dev)
     Just fd <- fmap (\(Handle__ { haDevice = dev }) ->
       fmap fdFD (cast dev)) $ readMVar write_handle_mvar
-#endif
 
     -- Finally, turn that (C-land) FD into a HANDLE using msvcrt
     windows_handle <- cget_osfhandle fd
@@ -470,13 +459,8 @@ withHandleToHANDLE haskell_handle action =
 -- This essential function comes from the C runtime system. It is certainly
 -- provided by msvcrt, and also seems to be provided by the mingw C library -
 -- hurrah!
-#if __GLASGOW_HASKELL__ >= 612
 foreign import WINDOWS_CCONV unsafe "_get_osfhandle"
   cget_osfhandle :: CInt -> IO HANDLE
-#else
-foreign import WINDOWS_CCONV unsafe "_get_osfhandle"
-  cget_osfhandle :: IOBase.FD -> IO HANDLE
-#endif
 
 -- withStablePtr was added in Win32-2.5.1.0
 withStablePtr :: a -> (StablePtr a -> IO b) -> IO b

--- a/System/Win32/Compat.hs
+++ b/System/Win32/Compat.hs
@@ -1,0 +1,110 @@
+{-# OPTIONS_HADDOCK hide #-}
+
+{-| The Win32 library ships with GHC. Win32-2.1 first shipped with GHC 6.6
+(released October 2006). Win32-2.5.4.1 first shipped with GHC 8.2.1
+(released July 2017), replacing Win32-2.3.1.1.
+
+The ansi-terminal library makes use of functionality in Win32-2.1 and other
+functionality first added to Win32-2.5.0.0 or Win32-2.5.1.0 (from ansi-terminal
+itself).
+
+This module provides functions available in those later versions of Win32 to a
+wider range of compilers, reducing the use of CPP pragmas in other modules.
+-}
+module System.Win32.Compat
+  (
+    BOOL
+  , DWORD
+  , ErrCode
+  , HANDLE
+  , LPCTSTR
+  , LPDWORD
+  , SHORT                -- from Win32-2.5.0.0
+  , TCHAR
+  , UINT
+  , WORD
+  , failIfFalse_
+  , getLastError
+  , iNVALID_HANDLE_VALUE
+  , nullHANDLE
+  , withHandleToHANDLE   -- from Win32-2.5.1.0
+  , withTString
+  ) where
+
+#if !MIN_VERSION_Win32(2,5,0)
+import Foreign.C.Types (CShort (..))
+#endif
+
+#if !MIN_VERSION_Win32(2,5,1)
+import Control.Concurrent.MVar (readMVar)
+import Control.Exception (bracket)
+import Foreign.StablePtr (StablePtr, freeStablePtr, newStablePtr)
+import Data.Typeable (cast)
+import GHC.IO.FD (FD(..)) -- A wrapper around an Int32
+import GHC.IO.Handle.Types (Handle (..), Handle__ (..))
+#endif
+
+import System.Win32.Types (BOOL, DWORD, ErrCode, HANDLE, LPCTSTR, LPDWORD,
+  TCHAR, UINT, WORD, failIfFalse_, getLastError, iNVALID_HANDLE_VALUE,
+  nullHANDLE, withTString)
+
+#if MIN_VERSION_Win32(2,5,0)
+import System.Win32.Types (SHORT)
+#endif
+
+#if MIN_VERSION_Win32(2,5,1)
+import System.Win32.Types (withHandleToHANDLE)
+#endif
+
+#if !MIN_VERSION_Win32(2,5,0)
+type SHORT = CShort
+#endif
+
+#if !MIN_VERSION_Win32(2,5,1)
+
+#if defined(i386_HOST_ARCH)
+#define WINDOWS_CCONV stdcall
+#elif defined(x86_64_HOST_ARCH)
+#define WINDOWS_CCONV ccall
+#else
+#error Unknown mingw32 arch
+#endif
+
+-- | This bit is all highly dubious. The problem is that we want to output ANSI
+-- to arbitrary Handles rather than forcing people to use stdout.  However, the
+-- Windows ANSI emulator needs a Windows HANDLE to work it's magic, so we need
+-- to be able to extract one of those from the Haskell Handle.
+--
+-- This code accomplishes this, albeit at the cost of only being compatible with
+-- GHC.
+withHandleToHANDLE :: Handle -> (HANDLE -> IO a) -> IO a
+withHandleToHANDLE haskell_handle action =
+  -- Create a stable pointer to the Handle. This prevents the garbage collector
+  -- getting to it while we are doing horrible manipulations with it, and hence
+  -- stops it being finalized (and closed).
+  withStablePtr haskell_handle $ const $ do
+    -- Grab the write handle variable from the Handle
+    let write_handle_mvar = case haskell_handle of
+          FileHandle _ handle_mvar     -> handle_mvar
+          DuplexHandle _ _ handle_mvar -> handle_mvar -- This is "write" MVar,
+          -- we could also take the "read" one
+
+    -- Get the FD from the algebraic data type
+    Just fd <- fmap (\(Handle__ { haDevice = dev }) ->
+      fmap fdFD (cast dev)) $ readMVar write_handle_mvar
+
+    -- Finally, turn that (C-land) FD into a HANDLE using msvcrt
+    windows_handle <- cget_osfhandle fd
+
+    -- Do what the user originally wanted
+    action windows_handle
+
+-- This essential function comes from the C runtime system. It is certainly
+-- provided by msvcrt, and also seems to be provided by the mingw C library -
+-- hurrah!
+foreign import WINDOWS_CCONV unsafe "_get_osfhandle"
+  cget_osfhandle :: CInt -> IO HANDLE
+
+withStablePtr :: a -> (StablePtr a -> IO b) -> IO b
+withStablePtr value = bracket (newStablePtr value) freeStablePtr
+#endif

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -49,6 +49,7 @@ Library
                                         System.Console.ANSI.Windows.Foreign
                                         -- NB: used for fallback by the emulator
                                         System.Console.ANSI.Unix
+                                        System.Win32.Compat
         else
                 -- We assume any non-Windows platform is Unix
                 Cpp-Options:            -DUNIX
@@ -79,6 +80,7 @@ Executable ansi-terminal-example
                                         System.Console.ANSI.Windows.Emulator
                                         System.Console.ANSI.Windows.Emulator.Codes
                                         System.Console.ANSI.Windows.Foreign
+                                        System.Win32.Compat
         else
                 -- We assume any non-Windows platform is Unix
                 Cpp-Options:            -DUNIX


### PR DESCRIPTION
This PR builds on #55. After #55, the remaining CPP pragmas in module `System.Console.ANSI.Windows.Foreign` are there to provide functions available in later versions of the `Win32` package that did not ship with versions of GHC before GHC 8.2.1.

This proposal refactors the code to make that explicit, creating module `System.Win32.Compat` (following the naming convention used in package `base-compat`). The intention is to make the logic of the `ansi-terminal` code more explicit.