### PR TITLE
Fix #57

### DIFF
--- a/System/Console/ANSI/Windows/Foreign.hs
+++ b/System/Console/ANSI/Windows/Foreign.hs
@@ -50,6 +50,9 @@ module System.Console.ANSI.Windows.Foreign
     ConsoleException (..)
   ) where
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>))
+#endif
 import Control.Exception (Exception, throw)
 import Data.Bits ((.|.), shiftL)
 import Data.Char (chr, ord)

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -39,7 +39,7 @@ Library
                               , colour
         if os(windows)
                 Build-Depends:          base-compat >= 0.9.1
-                                      , containers
+                                      , containers >= 0.5.0.0
                                       , Win32 >= 2.0
                 Cpp-Options:            -DWINDOWS
                 Other-Modules:          System.Console.ANSI.Windows
@@ -71,7 +71,7 @@ Executable ansi-terminal-example
 
         if os(windows)
                 Build-Depends:          base-compat >= 0.9.1
-                                      , containers
+                                      , containers >= 0.5.0.0
                                       , Win32 >= 2.0
                 Cpp-Options:            -DWINDOWS
                 Other-Modules:          System.Console.ANSI.Windows


### PR DESCRIPTION
Seeks to fix the issues identified in PR #57 in respect of earlier versions of GHC by importing `<$>` and `<*>`, and specifying a lower bound for `containers`.