### PR TITLE
Improve hSupportsANSI, on Windows

### DIFF
--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -40,6 +40,7 @@ Library
                               , colour
         if os(windows)
                 Build-Depends:          containers >= 0.5.0.0
+                                      , mintty
                                       , Win32 >= 2.0
                 Cpp-Options:            -DWINDOWS
                 Other-Modules:          System.Console.ANSI.Windows

--- a/src/System/Console/ANSI/Unix.hs
+++ b/src/System/Console/ANSI/Unix.hs
@@ -9,6 +9,7 @@ module System.Console.ANSI.Unix
   ) where
 
 import Control.Exception.Base (bracket)
+import System.Environment (getEnvironment)
 import System.IO (BufferMode (..), Handle, hFlush, hGetBuffering, hGetEcho,
   hIsTerminalDevice, hPutStr, hSetBuffering, hSetEcho, stdin, stdout)
 import Text.ParserCombinators.ReadP (readP_to_S)
@@ -60,6 +61,16 @@ hHideCursor h = hPutStr h hideCursorCode
 hShowCursor h = hPutStr h showCursorCode
 
 hSetTitle h title = hPutStr h $ setTitleCode title
+
+-- hSupportsANSI :: Handle -> IO Bool
+-- (See Common-Include.hs for Haddock documentation)
+--
+-- Borrowed from an HSpec patch by Simon Hengel
+-- (https://github.com/hspec/hspec/commit/d932f03317e0e2bd08c85b23903fb8616ae642bd)
+hSupportsANSI h = (&&) <$> hIsTerminalDevice h <*> isNotDumb
+ where
+  -- cannot use lookupEnv since it only appeared in GHC 7.6
+  isNotDumb = (/= Just "dumb") . lookup "TERM" <$> getEnvironment
 
 -- getReportedCursorPosition :: IO String
 -- (See Common-Include.hs for Haddock documentation)

--- a/src/System/Console/ANSI/Windows.hs
+++ b/src/System/Console/ANSI/Windows.hs
@@ -8,7 +8,7 @@ module System.Console.ANSI.Windows
 #include "Exports-Include.hs"
   ) where
 
-import System.IO (Handle, hIsTerminalDevice, stdout)
+import System.IO (Handle, stdout)
 
 import System.Console.ANSI.Types
 import qualified System.Console.ANSI.Unix as U
@@ -177,6 +177,10 @@ hSetTitle = nativeOrEmulated U.hSetTitle E.hSetTitle
 
 setTitleCode :: String -> String
 setTitleCode = nativeOrEmulated U.setTitleCode E.setTitleCode
+
+-- hSupportsANSI :: Handle -> IO Bool
+-- (See Common-Include.hs for Haddock documentation)
+hSupportsANSI = E.hSupportsANSI
 
 -- getReportedCursorPosition :: IO String
 -- (See Common-Include.hs for Haddock documentation)

--- a/src/includes/Common-Include.hs
+++ b/src/includes/Common-Include.hs
@@ -4,7 +4,6 @@
 -- of the corresponding more general functions, inclduding the related Haddock
 -- documentation.
 
-import System.Environment
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
 #endif
@@ -95,21 +94,19 @@ setTitle = hSetTitle stdout
 -- | Use heuristics to determine whether the functions defined in this
 -- package will work with a given handle.
 --
--- For Unix-like operating systems or Windows, the current implementation checks
--- that: (1) the handle is a terminal (see further below); and (2) a @TERM@
+-- For Unix-like operating systems, the current implementation checks
+-- that: (1) the handle is a terminal; and (2) a @TERM@
 -- environment variable is not set to @dumb@ (which is what the GNU Emacs text
 -- editor sets for its integrated terminal).
 --
--- The function 'hIsTerminalDevice' is used to check if the handle is a
--- terminal. However, on Windows, this function may not identify a handle to a
--- non-native terminal (for example, 'mintty') as a terminal.
+-- For Windows, the current implementation performs the same checks as for
+-- Unix-like operating systems and, as an alternative, checks whether the
+-- handle is connected to a \'mintty\' terminal. (That is because the function
+-- 'hIsTerminalDevice' is used to check if the handle is a
+-- terminal. However, where a non-native Windows terminal (such as \'mintty\')
+-- is implemented using redirection, that function will not identify a
+-- handle to the terminal as a terminal.)
 hSupportsANSI :: Handle -> IO Bool
--- Borrowed from an HSpec patch by Simon Hengel
--- (https://github.com/hspec/hspec/commit/d932f03317e0e2bd08c85b23903fb8616ae642bd)
-hSupportsANSI h = (&&) <$> hIsTerminalDevice h <*> (not <$> isDumb)
- where
-  -- cannot use lookupEnv since it only appeared in GHC 7.6
-  isDumb = maybe False (== "dumb") . lookup "TERM" <$> getEnvironment
 
 -- | Parses the characters emitted by 'reportCursorPosition' into the console
 -- input stream. Returns the cursor row and column as a tuple.


### PR DESCRIPTION
For Windows builds only, use the functionality of the `mintty` package to test whether a handle is connected to a 'mintty' terminal, which is not detected by `hIsTerminalDevice` from `System.IO`. Update the documentation, accordingly.

This proposal is in response to part of https://github.com/commercialhaskell/stack/issues/3992. Version 1.7.1 of the Haskell Tool Stack is relying on `hSupportsANSI`, which does not currently work for non-native Windows terminals like 'mintty' because it, in turn, relies on `hIsTerminalDevice`.

I have tested this on Windows 10 and OS X - and tested that it cures the `stack` problem with a 'mintty' terminal.

The `mintty` package depends on `Win32` (as does `ansi-terminal`; `mintty` backports functionality first introduced in `Win32-2.5.0.0`), `filepath` (included with GHC) and `base (>= 4.3 && < 5)`. `base-4.3.0.0` shipped with GHC 7.0.1 (November 2010), which is the version of GHC which introduced Haskell 2010 (specified as the default language in the cabal file for `mintty`). However, `ansi-terminal` currently depends on `base (>= 4.2.0.0)`. `base-4.2.0.0` shipped with GHC 6.12.1 (December 2009). Perhaps it is no longer necessary for `ansi-terminal` to support in its current versions such an outdated version of GHC.