### PR TITLE
Add #68: `hSupportsANSIWithoutEmulation`

### DIFF
--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -36,7 +36,7 @@ Library
 
         Include-Dirs:           src/includes
 
-        Build-Depends:          base >= 4.2.0.0 && < 5
+        Build-Depends:          base >= 4.3.0.0 && < 5
                               , colour
         if os(windows)
                 Build-Depends:          containers >= 0.5.0.0
@@ -64,7 +64,7 @@ Library
 Executable ansi-terminal-example
         Hs-Source-Dirs:         app
         Main-Is:                Example.hs
-        Build-Depends:          base >= 4.2.0.0 && < 5
+        Build-Depends:          base >= 4.3.0.0 && < 5
                               , ansi-terminal
         Ghc-Options:            -Wall
         if !flag(example)

--- a/src/System/Console/ANSI/Unix.hs
+++ b/src/System/Console/ANSI/Unix.hs
@@ -11,7 +11,8 @@ module System.Console.ANSI.Unix
 import Control.Exception.Base (bracket)
 import System.Environment (getEnvironment)
 import System.IO (BufferMode (..), Handle, hFlush, hGetBuffering, hGetEcho,
-  hIsTerminalDevice, hPutStr, hSetBuffering, hSetEcho, stdin, stdout)
+  hIsTerminalDevice, hIsWritable, hPutStr, hSetBuffering, hSetEcho, stdin,
+  stdout)
 import Text.ParserCombinators.ReadP (readP_to_S)
 
 import System.Console.ANSI.Codes
@@ -71,6 +72,11 @@ hSupportsANSI h = (&&) <$> hIsTerminalDevice h <*> isNotDumb
  where
   -- cannot use lookupEnv since it only appeared in GHC 7.6
   isNotDumb = (/= Just "dumb") . lookup "TERM" <$> getEnvironment
+
+-- hSupportsANSIWithoutEmulation :: Handle -> IO (Maybe Bool)
+-- (See Common-Include.hs for Haddock documentation)
+hSupportsANSIWithoutEmulation h =
+  Just <$> ((&&) <$> hIsWritable h <*> hSupportsANSI h)
 
 -- getReportedCursorPosition :: IO String
 -- (See Common-Include.hs for Haddock documentation)

--- a/src/System/Console/ANSI/Windows.hs
+++ b/src/System/Console/ANSI/Windows.hs
@@ -182,6 +182,10 @@ setTitleCode = nativeOrEmulated U.setTitleCode E.setTitleCode
 -- (See Common-Include.hs for Haddock documentation)
 hSupportsANSI = E.hSupportsANSI
 
+-- hSupportsANSIWithoutEmulation :: Handle -> IO (Maybe Bool)
+-- (See Common-Include.hs for Haddock documentation)
+hSupportsANSIWithoutEmulation = E.hSupportsANSIWithoutEmulation
+
 -- getReportedCursorPosition :: IO String
 -- (See Common-Include.hs for Haddock documentation)
 getReportedCursorPosition = E.getReportedCursorPosition

--- a/src/System/Console/ANSI/Windows/Detect.hs
+++ b/src/System/Console/ANSI/Windows/Detect.hs
@@ -5,11 +5,17 @@ module System.Console.ANSI.Windows.Detect
     ANSISupport (..)
   , ConsoleDefaultState (..)
   , aNSISupport
+  , detectHandleSupportsANSI
   ) where
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>))
+#endif
 
 import Control.Exception (SomeException(..), throwIO, try)
 import Data.Bits ((.&.), (.|.))
-import System.IO (stdout)
+import System.Console.MinTTY (isMinTTYHandle)
+import System.IO (Handle, hIsWritable, stdout)
 import System.IO.Unsafe (unsafePerformIO)
 
 import System.Console.ANSI.Windows.Foreign (ConsoleException(..),
@@ -31,44 +37,77 @@ data ANSISupport
                                  -- the console when that status was determined)
   deriving (Eq, Show)
 
+-- | Terminals on Windows
+data Terminal
+  = NativeANSIEnabled    -- ^ Windows 10 (Command Prompt or PowerShell)
+  | NativeANSIIncapable  -- ^ Versions before Windows 10 (Command Prompt or
+                         -- PowerShell)
+  | Mintty               -- ^ ANSI-enabled
+  | UnknownTerminal
+
 -- | This function assumes that once it is first established whether or not the
 -- Windows console requires emulation, that will not change. If the console
 -- requires emulation, the state of the console is considered to be its default
 -- state.
 {-# NOINLINE aNSISupport #-}
 aNSISupport :: ANSISupport
-aNSISupport = unsafePerformIO $ withHandleToHANDLE stdout aNSISupport'
-
--- | This function first checks if the Windows handle is valid and throws an
--- exception if it is not. It then tries to get a ConHost console mode for
--- that handle. If it can not, it assumes that the handle is ANSI-enabled. If
--- virtual termimal (VT) processing is already enabled, the handle does not
--- require emulation. Otherwise, it trys to enable processing. If it can, the
--- handle is ANSI-enabled. If it can not, emulation will be attempted and the
--- state of the console is considered to be its default state.
-aNSISupport' :: HANDLE -> IO ANSISupport
-aNSISupport' h =
-  if h == iNVALID_HANDLE_VALUE || h == nullHANDLE
-    then throwIO $ ConsoleException 6  -- Invalid handle or no handle
-    else do
-      tryMode <- try (getConsoleMode h) :: IO (Either SomeException DWORD)
-      case tryMode of
-        Left _     -> return Native  -- No ConHost mode
-        Right mode -> if mode .&. eNABLE_VIRTUAL_TERMINAL_PROCESSING /= 0
-          then return Native  -- VT processing already enabled
-          else do
-            let mode' = mode .|. eNABLE_VIRTUAL_TERMINAL_PROCESSING
-            trySetMode <- try (setConsoleMode h mode') :: IO (Either SomeException ())
-            case trySetMode of
-              Left _   -> emulated       -- Can't enable VT processing
-              Right () -> return Native  -- VT processing enabled
+aNSISupport = unsafePerformIO $ withHandleToHANDLE stdout $ withHANDLE
+  (throwIO $ ConsoleException 6)  -- Invalid handle or no handle
+  (\h -> do
+    terminal <- handleToTerminal h
+    case terminal of
+      NativeANSIIncapable -> Emulated <$> consoleDefaultState h
+      _                   -> return Native)
  where
-  emulated = do
+  consoleDefaultState h = do
     info <- getConsoleScreenBufferInfo h
     let attributes = csbi_attributes info
         fgAttributes = attributes .&. fOREGROUND_INTENSE_WHITE
         bgAttributes = attributes .&. bACKGROUND_INTENSE_WHITE
-        consoleDefaultState = ConsoleDefaultState
-          { defaultForegroundAttributes = fgAttributes
-          , defaultBackgroundAttributes = bgAttributes }
-    return $ Emulated consoleDefaultState
+    return ConsoleDefaultState
+      { defaultForegroundAttributes = fgAttributes
+      , defaultBackgroundAttributes = bgAttributes }
+
+-- | This function tests that the handle is writable. If what is attached to the
+-- handle is not recognised as a known terminal, it returns @return Nothing@.
+detectHandleSupportsANSI :: Handle -> IO (Maybe Bool)
+detectHandleSupportsANSI handle = do
+  isWritable <- hIsWritable handle
+  if isWritable
+    then withHandleToHANDLE handle $ withHANDLE
+      (return $ Just False)  -- Invalid handle or no handle
+      (\h -> do
+        terminal <- handleToTerminal h
+        case terminal of
+          NativeANSIIncapable -> return (Just False)
+          UnknownTerminal     -> return Nothing  -- Not sure!
+          _                   -> return (Just True))
+    else return (Just False)  -- Not an output handle
+
+-- | This function assumes that the Windows handle is writable.
+handleToTerminal :: HANDLE -> IO Terminal
+handleToTerminal h = do
+  tryMode <- try (getConsoleMode h) :: IO (Either SomeException DWORD)
+  case tryMode of
+    Left _     -> do  -- No ConHost mode
+      isMinTTY <- isMinTTYHandle h
+      if isMinTTY
+        then return Mintty  -- 'mintty' terminal emulator
+        else return UnknownTerminal  -- Not sure!
+    Right mode -> if mode .&. eNABLE_VIRTUAL_TERMINAL_PROCESSING /= 0
+      then return NativeANSIEnabled  -- VT processing already enabled
+      else do
+        let mode' = mode .|. eNABLE_VIRTUAL_TERMINAL_PROCESSING
+        trySetMode <- try (setConsoleMode h mode')
+          :: IO (Either SomeException ())
+        case trySetMode of
+          Left _   -> return NativeANSIIncapable  -- Can't enable VT processing
+          Right () -> return NativeANSIEnabled  -- VT processing enabled
+
+-- | This function applies another to the Windows handle, if the handle is
+-- valid. If it is invalid, the specified default action is returned.
+withHANDLE :: IO a -> (HANDLE -> IO a) -> HANDLE -> IO a
+withHANDLE invalid action h =
+  if h == iNVALID_HANDLE_VALUE || h == nullHANDLE
+    then invalid  -- Invalid handle or no handle
+    else action h

--- a/src/includes/Exports-Include.hs
+++ b/src/includes/Exports-Include.hs
@@ -107,6 +107,7 @@
 
     -- * Checking if handle supports ANSI (not portable: GHC only)
   , hSupportsANSI
+  , hSupportsANSIWithoutEmulation
 
     -- * Getting the cursor position
   , getCursorPosition

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 extra-deps: []
-resolver: lts-12.0
+resolver: lts-12.8
 flags:
   ansi-terminal:
     example: false


### PR DESCRIPTION
Utility `hSupportsANSIWithoutEmulation :: Handle -> IO (Maybe Bool)` is added, as described in its Haddock documentation in `Common-Include.hs`. The Haddock documentation of existing `hSupportsANSI` is updated, to clarify the difference between the two functions. A key benefit of the new utility is that, on Windows 10 and a native terminal and with a writable `Handle`, it 'turns on' the processing of 'ANSI' control characters sent to output.

As the new utility is likely to be used outside of the rest of the `ansi-terminal` package (as it is of most use where the existence of the package's emulation layer on legacy Windows is not being relied upon), the utility expressly checks that the `Handle` is actually 'writable'. That is not done by `hSupportsANSI`, so `hSupportsANSI stdin` is `True` while `hSupportsANSIWithoutEmulation stdin` is `Just False`.

Most of the work is done in module `System.Windows.Console.ANSI.Detect`, which is refactored to break out the code that is re-purposed for export (as well as continuing to be used for the internal 'choice' between emulation or not). The key new helper function (not exported) is `handleToTerminal :: HANDLE -> IO Terminal`, where `Terminal` (not exported) is the terminal on Windows. In module `System.Windows.Console.ANSI.Emulator`, the testing (if need be) of the environment variable `TERM` is added to the heuristic.

In passing, the `stack` resolver is bumped from 12.0 to the latest (12.8).

Some testing has been done on Windows 7 (native and mintty terminals), Windows 10 (native and mintty terminals) and macOS - but I am relying in part on the CI tests that occur when this pull request is created.