### PR TITLE
Enhance cursor pos docs (0- and 1-based) and add `getCursorPosition0`

### DIFF
--- a/app/Example.hs
+++ b/app/Example.hs
@@ -301,11 +301,11 @@ getCursorPositionExample = do
   --          11111111112222222222
   -- 12345678901234567890123456789
   -- Report cursor position here:|
-  result <- getCursorPosition
+  result <- getCursorPosition0
   putStrLn " (3rd row, 29th column) to stdin, as CSI 3 ; 29 R.\n"
   case result of
     Just (row, col) -> putStrLn $ "The cursor was at row number " ++
-      show row ++ " and column number " ++ show col ++ ".\n"
+      show (row + 1) ++ " and column number " ++ show (col + 1) ++ ".\n"
     Nothing -> putStrLn "Error: unable to get the cursor position\n"
   pause
   --          11111111112222222222

--- a/src/System/Console/ANSI.hs
+++ b/src/System/Console/ANSI.hs
@@ -22,6 +22,13 @@
 --
 --  * Changing the title of the terminal
 --
+-- The functions moving the cursor to an absolute position are 0-based (the
+-- top-left corner is considered to be at row 0 column 0) (see
+-- 'setCursorPosition') and so is 'getCursorPosition0'. The \'ANSI\' standards
+-- themselves are 1-based (that is, the top-left corner is considered to be at
+-- row 1 column 1) and some functions reporting the position of the cursor are
+-- too (see 'reportCursorPosition').
+--
 -- The native terminal software on Windows is \'Command Prompt\' or
 -- \`PowerShell\`. Before Windows 10 version 1511 (known as the \'November
 -- [2015] Update\' or \'Threshold 2\') that software did not support such

--- a/src/System/Console/ANSI/Codes.hs
+++ b/src/System/Console/ANSI/Codes.hs
@@ -134,18 +134,42 @@ cursorDownLineCode, cursorUpLineCode :: Int -- ^ Number of lines to move
 cursorDownLineCode n = csi [n] "E"
 cursorUpLineCode n = csi [n] "F"
 
+-- | Code to move the cursor to the specified column. The column numbering is
+-- 0-based (that is, the left-most column is numbered 0).
 setCursorColumnCode :: Int -- ^ 0-based column to move to
                     -> String
 setCursorColumnCode n = csi [n + 1] "G"
 
+-- | Code to move the cursor to the specified position (row and column). The
+-- position is 0-based (that is, the top-left corner is at row 0 column 0).
 setCursorPositionCode :: Int -- ^ 0-based row to move to
                       -> Int -- ^ 0-based column to move to
                       -> String
 setCursorPositionCode n m = csi [n + 1, m + 1] "H"
 
-saveCursorCode, restoreCursorCode, reportCursorPositionCode :: String
+-- | @since 0.7.1
+saveCursorCode, restoreCursorCode :: String
 saveCursorCode = "\ESC7"
 restoreCursorCode = "\ESC8"
+
+-- | Code to emit the cursor position into the console input stream, immediately
+-- after being recognised on the output stream, as:
+-- @ESC [ \<cursor row> ; \<cursor column> R@
+--
+-- Note that the information that is emitted is 1-based (the top-left corner is
+-- at row 1 column 1) but 'setCursorPositionCode' is 0-based.
+--
+-- In isolation of 'getReportedCursorPosition' or 'getCursorPosition0', this
+-- function may be of limited use on Windows operating systems because of
+-- difficulties in obtaining the data emitted into the console input stream.
+-- The function 'hGetBufNonBlocking' in module "System.IO" does not work on
+-- Windows. This has been attributed to the lack of non-blocking primatives in
+-- the operating system (see the GHC bug report #806 at
+-- <https://ghc.haskell.org/trac/ghc/ticket/806>).
+--
+-- @since 0.7.1
+reportCursorPositionCode :: String
+
 reportCursorPositionCode = csi [] "6n"
 
 clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode,

--- a/src/System/Console/ANSI/Unix.hs
+++ b/src/System/Console/ANSI/Unix.hs
@@ -101,6 +101,7 @@ getReportedCursorPosition = bracket (hGetEcho stdin) (hSetEcho stdin) $ \_ -> do
 
 -- getCursorPosition :: IO (Maybe (Int, Int))
 -- (See Common-Include.hs for Haddock documentation)
+{-# DEPRECATED getCursorPosition "Use getCursorPosition0 instead." #-}
 getCursorPosition = do
   input <- bracket (hGetBuffering stdin) (hSetBuffering stdin) $ \_ -> do
     hSetBuffering stdin NoBuffering -- set no buffering (the contents of the

--- a/src/System/Console/ANSI/Windows.hs
+++ b/src/System/Console/ANSI/Windows.hs
@@ -192,4 +192,5 @@ getReportedCursorPosition = E.getReportedCursorPosition
 
 -- getCursorPosition :: IO (Maybe (Int, Int))
 -- (See Common-Include.hs for Haddock documentation)
+{-# DEPRECATED getCursorPosition "Use getCursorPosition0 instead." #-}
 getCursorPosition = E.getCursorPosition

--- a/src/includes/Exports-Include.hs
+++ b/src/includes/Exports-Include.hs
@@ -110,6 +110,9 @@
   , hSupportsANSIWithoutEmulation
 
     -- * Getting the cursor position
-  , getCursorPosition
+  , getCursorPosition0
   , getReportedCursorPosition
   , cursorPosition
+
+    -- * Deprecated
+  , getCursorPosition


### PR DESCRIPTION
See #71. The 'ANSI' standards are 1-based but the long-settled API for `setCursorColumn` and `setCursorPosition` is 0-based. The 'ANSI' standards determine what is emitted by `reportCursorPosition` and, consequently, the values of `getCursorPosition`. This pull request enhances the Haddock documentation of those families of functions to seek to reduce the chance that users will assume the `set` and `get` functions number rows and columns in the same way.