### PR TITLE
Add `getTerminalSize`

### DIFF
--- a/app/Example.hs
+++ b/app/Example.hs
@@ -24,6 +24,7 @@ examples = [ cursorMovementExample
            , cursorVisibilityExample
            , titleExample
            , getCursorPositionExample
+           , getTerminalSizeExample
            ]
 
 main :: IO ()
@@ -393,9 +394,19 @@ getCursorPositionExample = do
     Just (row, col) -> putStrLn $ "The cursor was at row number " ++
       show (row + 1) ++ " and column number " ++ show (col + 1) ++ ".\n"
     Nothing -> putStrLn "Error: unable to get the cursor position\n"
-  pause
+  replicateM_ 3 pause
   --          11111111112222222222
   -- 12345678901234567890123456789
   -- Report cursor position here: (3rd row, 29th column) to stdin, as CSI 3 ; 29 R.
   --
   -- The cursor was at row number 3 and column number 29.
+
+getTerminalSizeExample :: IO ()
+getTerminalSizeExample = do
+  result <- getTerminalSize
+  case result of
+    Just (h, w) -> putStrLn $ "The size of the terminal is " ++ show h ++
+      " rows by " ++ show w ++ " columns.\n"
+    Nothing -> putStrLn "Error: unable to get the terminal size\n"
+  pause
+  -- The size of the terminal is 25 rows by 80 columns.

--- a/src/includes/Common-Include.hs
+++ b/src/includes/Common-Include.hs
@@ -244,3 +244,21 @@ getCursorPosition0 = fmap to0base <$> getCursorPosition
 --
 -- @since 0.7.1
 getCursorPosition :: IO (Maybe (Int, Int))
+
+-- | Attempts to get the current terminal size (height in rows, width in
+-- columns), by using `getCursorPosition0` after attempting to set the cursor
+-- position beyond the bottom right corner of the terminal.
+--
+-- On Windows operating systems, the function is not supported on consoles, such
+-- as mintty, that are not based on the Win32 console of the Windows API.
+-- (Command Prompt and PowerShell are based on the Win32 console.)
+--
+-- @since 0.9
+getTerminalSize :: IO (Maybe (Int, Int))
+getTerminalSize = do
+  saveCursor
+  setCursorPosition 999 999  -- Attempt to set the cursor position beyond the
+                             -- bottom right corner of the terminal.
+  mPos <- getCursorPosition0
+  restoreCursor
+  return $ fmap (\(r, c) -> (r + 1, c + 1)) mPos

--- a/src/includes/Exports-Include.hs
+++ b/src/includes/Exports-Include.hs
@@ -115,5 +115,8 @@
   , getReportedCursorPosition
   , cursorPosition
 
+    -- * Getting the terminal size
+  , getTerminalSize
+
     -- * Deprecated
   , getCursorPosition


### PR DESCRIPTION
In response to #77, adds `getTerminalSize` and a corresponding example to `Example.hs`.