### PR TITLE
Add Safe Haskell annotations

### DIFF
--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -16,6 +16,7 @@ Build-Type:          Simple
 Extra-Source-Files:     src/includes/Common-Include.hs
                         src/includes/Common-Include-Emulator.hs
                         src/includes/Common-Include-Enabled.hs
+                        src/includes/Common-Safe-Haskell.hs
                         src/includes/Exports-Include.hs
                         CHANGELOG.md
                         README.md

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -38,7 +38,7 @@ Library
         Include-Dirs:           src/includes
 
         Build-Depends:          base >= 4.3.0.0 && < 5
-                              , colour
+                              , colour >=2.1.0
         if os(windows)
                 Build-Depends:          containers >= 0.5.0.0
                                       , mintty

--- a/src/System/Console/ANSI.hs
+++ b/src/System/Console/ANSI.hs
@@ -97,6 +97,9 @@
 --
 -- For many more examples, see the project's extensive
 -- <https://github.com/feuerbach/ansi-terminal/blob/master/app/Example.hs Example.hs> file.
+
+#include "Common-Safe-Haskell.hs"
+
 #if defined(WINDOWS)
 module System.Console.ANSI
   (

--- a/src/System/Console/ANSI/Codes.hs
+++ b/src/System/Console/ANSI/Codes.hs
@@ -14,6 +14,9 @@
 --
 -- > import qualified System.Console.ANSI.Codes as ANSI
 --
+
+#include "Common-Safe-Haskell.hs"
+
 module System.Console.ANSI.Codes
   (
     -- * Basic data types

--- a/src/System/Console/ANSI/Types.hs
+++ b/src/System/Console/ANSI/Types.hs
@@ -8,6 +8,10 @@
 --
 -- This module exports types and functions used to represent SGR aspects. See
 -- also 'System.Console.ANSI.setSGR' and related functions.
+--
+
+#include "Common-Safe-Haskell.hs"
+
 module System.Console.ANSI.Types
   (
   -- * Types used to represent SGR aspects

--- a/src/System/Console/ANSI/Unix.hs
+++ b/src/System/Console/ANSI/Unix.hs
@@ -1,3 +1,4 @@
+#include "Common-Safe-Haskell.hs"
 {-# OPTIONS_HADDOCK hide #-}
 
 module System.Console.ANSI.Unix

--- a/src/System/Console/ANSI/Windows.hs
+++ b/src/System/Console/ANSI/Windows.hs
@@ -1,3 +1,4 @@
+#include "Common-Safe-Haskell.hs"
 {-# OPTIONS_HADDOCK hide #-}
 
 module System.Console.ANSI.Windows

--- a/src/System/Console/ANSI/Windows/Detect.hs
+++ b/src/System/Console/ANSI/Windows/Detect.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Trustworthy #-}
+
 {-# OPTIONS_HADDOCK hide #-}
 
 module System.Console.ANSI.Windows.Detect

--- a/src/System/Console/ANSI/Windows/Emulator.hs
+++ b/src/System/Console/ANSI/Windows/Emulator.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Trustworthy #-}
+
 {-# OPTIONS_HADDOCK hide #-}
 
 module System.Console.ANSI.Windows.Emulator

--- a/src/System/Console/ANSI/Windows/Emulator/Codes.hs
+++ b/src/System/Console/ANSI/Windows/Emulator/Codes.hs
@@ -1,3 +1,5 @@
+#include "Common-Safe-Haskell.hs"
+
 {-# OPTIONS_HADDOCK hide #-}
 
 module System.Console.ANSI.Windows.Emulator.Codes

--- a/src/System/Console/ANSI/Windows/Foreign.hs
+++ b/src/System/Console/ANSI/Windows/Foreign.hs
@@ -1,3 +1,5 @@
+#include "Common-Safe-Haskell.hs"
+
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DeriveDataTypeable #-}
@@ -58,8 +60,12 @@ import Data.Bits ((.|.), shiftL)
 import Data.Char (chr, ord)
 import Data.Typeable (Typeable)
 import Foreign.C.Types (CInt (..), CWchar (..))
-import Foreign.Marshal (alloca, allocaArray, maybeWith, peekArray, with,
-  withArrayLen)
+#if MIN_VERSION_base(4,8,0)
+import Foreign.Marshal
+#else
+import Foreign.Marshal.Safe
+#endif
+  (alloca, allocaArray, maybeWith, peekArray, with, withArrayLen)
 import Foreign.Ptr (Ptr, castPtr, plusPtr)
 import Foreign.Storable (Storable (..))
 -- `SHORT` and `withHandleToHANDLE` are not both available before Win32-2.5.1.0

--- a/src/System/Win32/Compat.hs
+++ b/src/System/Win32/Compat.hs
@@ -1,3 +1,4 @@
+#include "Common-Safe-Haskell.hs"
 {-# OPTIONS_HADDOCK hide #-}
 
 {-| The Win32 library ships with GHC. Win32-2.1 first shipped with GHC 6.6

--- a/src/includes/Common-Safe-Haskell.hs
+++ b/src/includes/Common-Safe-Haskell.hs
@@ -1,0 +1,5 @@
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif


### PR DESCRIPTION
`ansi-terminal` is inferred safe; but to make this explicit it's better to have annotations.

I haven't yet tested the Windows codepaths; based on http://hackage.haskell.org/package/Win32-2.2.2.0/docs/System-Win32.html (bundled with GHC-7.4.2) `Win32` has explicit annotations too; so it *should* work.