### PR TITLE
Add SetDefaultColor SGR code

### DIFF
--- a/src/System/Console/ANSI/Codes.hs
+++ b/src/System/Console/ANSI/Codes.hs
@@ -121,6 +121,8 @@ sgrToCode sgr = case sgr of
   SetPaletteColor Background index -> [48, 5, fromIntegral index]
   SetRGBColor Foreground color -> [38, 2] ++ toRGB color
   SetRGBColor Background color -> [48, 2] ++ toRGB color
+  SetDefaultColor Foreground -> [39]
+  SetDefaultColor Background -> [49]
  where
   toRGB color = let RGB r g b = toSRGB24 color
                 in  map fromIntegral [r, g, b]

--- a/src/System/Console/ANSI/Types.hs
+++ b/src/System/Console/ANSI/Types.hs
@@ -132,6 +132,10 @@ data SGR
   --
   -- @since 0.9
   | SetPaletteColor !ConsoleLayer !Word8
+  -- | Set a color to the default (implementation-defined)
+  --
+  -- @since 0.9
+  | SetDefaultColor !ConsoleLayer
   deriving (Eq, Show, Read)
 
 -- | Given xterm's standard protocol for a 256-color palette, returns the index

--- a/src/System/Console/ANSI/Windows/Emulator.hs
+++ b/src/System/Console/ANSI/Windows/Emulator.hs
@@ -263,6 +263,12 @@ swapForegroundBackgroundColors attribute
 applyANSISGRToAttribute :: WORD -> SGR -> WORD -> WORD
 applyANSISGRToAttribute def sgr attribute = case sgr of
   Reset -> def
+  SetDefaultColor Foreground ->
+    (attribute .&. complement fOREGROUND_INTENSE_WHITE) .|.
+    (def .&. fOREGROUND_INTENSE_WHITE)
+  SetDefaultColor Background ->
+    (attribute .&. complement bACKGROUND_INTENSE_WHITE) .|.
+    (def .&. bACKGROUND_INTENSE_WHITE)
   SetConsoleIntensity intensity -> case intensity of
     BoldIntensity   -> attribute .|. iNTENSITY
     FaintIntensity  -> attribute .&. (complement iNTENSITY) -- Not supported


### PR DESCRIPTION
Adds SGR codes 39 and 49 which are implementation defined, but as far as I can tell they reset the color to the console default. I only tested it on Ubuntu's terminal, and OSx Terminal and iTerm2 though.