### PR TITLE
Fix #94 Add hGetCursorPosition, hGetTerminalSize

### DIFF
--- a/src/System/Console/ANSI/Unix.hs
+++ b/src/System/Console/ANSI/Unix.hs
@@ -98,9 +98,9 @@ getReportedCursorPosition = bracket (hGetEcho stdin) (hSetEcho stdin) $ \_ -> do
                       -- in order to avoid O(n^2) complexity.
       else return $ reverse (c:s) -- Reverse the order of the built list.
 
--- getCursorPosition0 :: IO (Maybe (Int, Int))
+-- hGetCursorPosition :: Handle -> IO (Maybe (Int, Int))
 -- (See Common-Include.hs for Haddock documentation)
-getCursorPosition0 = fmap to0base <$> getCursorPosition
+hGetCursorPosition h = fmap to0base <$> getCursorPosition
  where
   to0base (row, col) = (row - 1, col - 1)
   getCursorPosition = do
@@ -109,9 +109,9 @@ getCursorPosition0 = fmap to0base <$> getCursorPosition
                                       -- buffer will be discarded, so this needs
                                       -- to be done before the cursor positon is
                                       -- emitted)
-      reportCursorPosition
-      hFlush stdout -- ensure the report cursor position code is sent to the
-                    -- operating system
+      hReportCursorPosition h
+      hFlush h -- ensure the report cursor position code is sent to the
+               -- operating system
       getReportedCursorPosition
     case readP_to_S cursorPosition input of
       [] -> return Nothing

--- a/src/System/Console/ANSI/Windows.hs
+++ b/src/System/Console/ANSI/Windows.hs
@@ -191,6 +191,6 @@ hSupportsANSIWithoutEmulation = E.hSupportsANSIWithoutEmulation
 -- (See Common-Include.hs for Haddock documentation)
 getReportedCursorPosition = E.getReportedCursorPosition
 
--- getCursorPosition0 :: IO (Maybe (Int, Int))
+-- hGetCursorPosition :: Handle -> IO (Maybe (Int, Int))
 -- (See Common-Include.hs for Haddock documentation)
-getCursorPosition0 = E.getCursorPosition0
+hGetCursorPosition = E.hGetCursorPosition

--- a/src/System/Console/ANSI/Windows/Emulator.hs
+++ b/src/System/Console/ANSI/Windows/Emulator.hs
@@ -477,18 +477,18 @@ getReportedCursorPosition
       isKeyDown = keyEventKeyDown keyEventRecord
       isKeyDownEvent = eventType == 1 && isKeyDown
 
--- getCursorPosition0 :: IO (Maybe (Int, Int))
+-- hGetCursorPosition :: Handle -> IO (Maybe (Int, Int))
 -- (See Common-Include.hs for Haddock documentation)
-getCursorPosition0 = fmap to0base <$> getCursorPosition
+hGetCursorPosition h = fmap to0base <$> getCursorPosition
  where
   to0base (row, col) = (row - 1, col - 1)
   getCursorPosition = CE.catch getCursorPosition' getCPExceptionHandler
    where
     getCursorPosition' = do
       withHandleToHANDLE stdin flush -- Flush the console input buffer
-      reportCursorPosition
-      hFlush stdout -- ensure the report cursor position code is sent to the
-                    -- operating system
+      hReportCursorPosition h
+      hFlush h -- ensure the report cursor position code is sent to the
+               -- operating system
       input <- getReportedCursorPosition
       case readP_to_S cursorPosition input of
         [] -> return Nothing

--- a/src/includes/Exports-Include.hs
+++ b/src/includes/Exports-Include.hs
@@ -112,8 +112,10 @@
 
     -- * Getting the cursor position
   , getCursorPosition0
+  , hGetCursorPosition
   , getReportedCursorPosition
   , cursorPosition
 
     -- * Getting the terminal size
   , getTerminalSize
+  , hGetTerminalSize


### PR DESCRIPTION
Tested on Windows 10.  I will not be able to test on a Unix-like operating system before 28 September 2019.